### PR TITLE
Product polish roadmap + first feature plan (list continuation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,17 @@ Unit tests can't catch bugs that only appear in the real browser (CM6 update cyc
 
 When implementing new custom vim features, follow the conventions above.
 Upon completion, add documentation for the feature to the help page. After implementation, do an interactive browser test (see "Browser Testing" above) to verify the feature works end-to-end.
+
+## Git Workflow
+
+User-wide git workflow rules live in `~/CLAUDE.md`. Project-specific notes:
+
+- `main` deploys to GitHub Pages automatically via GitHub Actions on every push. Never push WIP to `main`; use a feature branch.
+- CI runs `lint + test + build` on every push. The full local equivalent is `npm run check` plus `npm run build`.
+- No long-lived feature branches in active use.
+
+## Roadmap & Reference Docs
+
+Active product direction lives in `docs/plans/2026-04-19-product-polish-roadmap.md` — design north star (Her + McFetridge), architectural commitments, scope (in and explicitly out), and the feature inventory that gets carved into per-feature plans.
+
+Vim scope is calibrated against the [Goerz vim quick reference card](https://michaelgoerz.net/refcards/vimqrc.pdf) ([source](https://github.com/goerz/Refcards/tree/master/vim)). It is the **negative scope doc**: anything on the card we explicitly aren't building (multi-windowing, tags, `:make`, shell, real filesystem, completion frameworks) is captured in the roadmap's "Out of Scope" section so we stop re-litigating those decisions.

--- a/docs/plans/2026-04-19-list-continuation.md
+++ b/docs/plans/2026-04-19-list-continuation.md
@@ -1,0 +1,485 @@
+# Auto-Continue Lists Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When pressing Enter in insert mode on a markdown list item, automatically begin the next line with the same marker, indent, and (for ordered lists) incremented number. Pressing Enter on an empty list marker terminates the list and leaves a blank line.
+
+**Architecture:** A pure function `continueListLine(lineText)` returns the prefix to insert on the next line — a string for continuation, the empty string for termination, or `null` for "no list continuation applies." A handler `handleListContinuation(cm, changeObj, state)` hooks into CM5 change events the same way `src/vim/textwidth.js` does — when an Enter character is inserted in insert mode, it inspects the preceding line and either inserts a continuation prefix at the cursor or strips the now-empty marker from the prior line. A `state.continuingList` recursion guard prevents re-entry. All edits are deferred via `setTimeout(..., 0)` to avoid CM6 update-cycle errors.
+
+**Tech Stack:** `@replit/codemirror-vim` CM5 compat layer, plain JavaScript (ESM), Vitest for unit tests, Playwright for browser verification.
+
+---
+
+## Task 0: Create the pure function with full unit tests
+
+**Files:**
+- Create: `src/vim/list-continuation.js`
+- Create: `src/vim/list-continuation.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/vim/list-continuation.test.js`:
+
+```js
+import { describe, test, expect } from 'vitest';
+import { continueListLine } from './list-continuation.js';
+
+describe('continueListLine', () => {
+  // Bullet lists -----------------------------------------------------------
+
+  test('continues unordered dash list', () => {
+    expect(continueListLine('- foo')).toBe('- ');
+  });
+
+  test('continues unordered asterisk list', () => {
+    expect(continueListLine('* foo')).toBe('* ');
+  });
+
+  test('continues unordered plus list', () => {
+    expect(continueListLine('+ foo')).toBe('+ ');
+  });
+
+  test('preserves leading indentation on bullet list', () => {
+    expect(continueListLine('  - foo')).toBe('  - ');
+  });
+
+  test('preserves deep indentation on bullet list', () => {
+    expect(continueListLine('      - foo')).toBe('      - ');
+  });
+
+  // Ordered lists ----------------------------------------------------------
+
+  test('increments single-digit ordered list', () => {
+    expect(continueListLine('1. foo')).toBe('2. ');
+  });
+
+  test('increments multi-digit ordered list', () => {
+    expect(continueListLine('10. foo')).toBe('11. ');
+  });
+
+  test('increments ordered list with parenthesis style', () => {
+    expect(continueListLine('1) foo')).toBe('2) ');
+  });
+
+  test('preserves indentation on ordered list', () => {
+    expect(continueListLine('  3. foo')).toBe('  4. ');
+  });
+
+  // Checkboxes (GFM) -------------------------------------------------------
+
+  test('continues unchecked task list as unchecked', () => {
+    expect(continueListLine('- [ ] task')).toBe('- [ ] ');
+  });
+
+  test('continues checked task list as unchecked (new task starts unchecked)', () => {
+    expect(continueListLine('- [x] task')).toBe('- [ ] ');
+  });
+
+  test('continues indented task list', () => {
+    expect(continueListLine('  - [ ] task')).toBe('  - [ ] ');
+  });
+
+  // Termination on empty markers ------------------------------------------
+
+  test('terminates on empty bullet marker', () => {
+    expect(continueListLine('- ')).toBe('');
+  });
+
+  test('terminates on empty asterisk marker', () => {
+    expect(continueListLine('* ')).toBe('');
+  });
+
+  test('terminates on empty ordered marker', () => {
+    expect(continueListLine('1. ')).toBe('');
+  });
+
+  test('terminates on empty indented marker', () => {
+    expect(continueListLine('    - ')).toBe('');
+  });
+
+  test('terminates on empty task marker (unchecked)', () => {
+    expect(continueListLine('- [ ] ')).toBe('');
+  });
+
+  test('terminates on empty task marker (checked)', () => {
+    expect(continueListLine('- [x] ')).toBe('');
+  });
+
+  // No-op cases ------------------------------------------------------------
+
+  test('returns null for non-list line', () => {
+    expect(continueListLine('foo bar')).toBe(null);
+  });
+
+  test('returns null for empty line', () => {
+    expect(continueListLine('')).toBe(null);
+  });
+
+  test('returns null for whitespace-only line', () => {
+    expect(continueListLine('   ')).toBe(null);
+  });
+
+  test('returns null for heading', () => {
+    expect(continueListLine('# Heading')).toBe(null);
+  });
+
+  test('returns null for blockquote (not handled in v1)', () => {
+    expect(continueListLine('> quote')).toBe(null);
+  });
+
+  test('returns null for line that starts with a digit but no list marker', () => {
+    expect(continueListLine('1 foo')).toBe(null);
+  });
+
+  test('returns null for line that starts with a dash but no space', () => {
+    expect(continueListLine('-foo')).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- src/vim/list-continuation.test.js
+```
+
+Expected: FAIL with "Failed to load url ./list-continuation.js" (module doesn't exist yet).
+
+- [ ] **Step 3: Implement the pure function**
+
+Create `src/vim/list-continuation.js`:
+
+```js
+/**
+ * Auto-continue markdown lists.
+ *
+ * Pure helper that decides what (if anything) should follow when the user
+ * presses Enter on a markdown list item. Returns:
+ *   - a string to insert as the next line's prefix (continuation), OR
+ *   - '' (empty string) to signal termination — the previous marker should
+ *     be cleared, the new line stays blank, OR
+ *   - null when the line isn't a recognized list item.
+ *
+ * Closest vim analogue: `formatoptions+=ro`, which is intentionally not
+ * implemented project-wide. This is a markdown-aware shim.
+ */
+
+// Captures: indent, marker, separator, content
+//   - bullets:  - * +  followed by a single space
+//   - ordered:  digits followed by . or ) and a single space
+//   - tasks:    bullet + "[ ]" or "[x]" + space
+var BULLET_RE = /^(\s*)([-*+]) (.*)$/;
+var ORDERED_RE = /^(\s*)(\d+)([.)]) (.*)$/;
+var TASK_RE = /^(\s*)([-*+]) \[([ xX])\] (.*)$/;
+
+export function continueListLine(lineText) {
+  // Task list takes precedence over plain bullet because the bullet RE
+  // would otherwise match the "- [ ]" prefix.
+  var task = lineText.match(TASK_RE);
+  if (task) {
+    var taskIndent = task[1];
+    var taskBullet = task[2];
+    var taskRest = task[4];
+    if (taskRest === '') return '';
+    return taskIndent + taskBullet + ' [ ] ';
+  }
+
+  var ordered = lineText.match(ORDERED_RE);
+  if (ordered) {
+    var orderedIndent = ordered[1];
+    var orderedNum = parseInt(ordered[2], 10);
+    var orderedSep = ordered[3];
+    var orderedRest = ordered[4];
+    if (orderedRest === '') return '';
+    return orderedIndent + (orderedNum + 1) + orderedSep + ' ';
+  }
+
+  var bullet = lineText.match(BULLET_RE);
+  if (bullet) {
+    var bulletIndent = bullet[1];
+    var bulletMarker = bullet[2];
+    var bulletRest = bullet[3];
+    if (bulletRest === '') return '';
+    return bulletIndent + bulletMarker + ' ';
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- src/vim/list-continuation.test.js
+```
+
+Expected: All 23 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vim/list-continuation.js src/vim/list-continuation.test.js
+git commit -m "feat(list-continuation): add pure continueListLine function with tests"
+```
+
+---
+
+## Task 1: Add the change-handler that wires the function to insert-mode Enter
+
+**Files:**
+- Modify: `src/vim/list-continuation.js`
+
+- [ ] **Step 1: Append the handler to the module**
+
+Add to the bottom of `src/vim/list-continuation.js`:
+
+```js
+/**
+ * Insert-mode change handler. Hooks the CM5 `change` event the same way
+ * src/vim/textwidth.js does. When the user presses Enter in insert mode
+ * on a markdown list item, applies continueListLine to either insert a
+ * continuation prefix on the new line or strip the empty marker from the
+ * line that was just split.
+ *
+ * Notes:
+ *   - We detect Enter by inspecting changeObj.text. CM5 represents a
+ *     single newline as ['', '']. Pasted multi-line text has non-empty
+ *     entries, so paste is naturally excluded.
+ *   - CM6 dispatch from inside a change handler throws; we defer with
+ *     setTimeout(..., 0).
+ *   - state.continuingList is the recursion guard.
+ */
+export function handleListContinuation(cm, changeObj, state) {
+  if (state.continuingList) return;
+  if (!cm.state.vim || !cm.state.vim.insertMode) return;
+
+  // Only react to a single newline insertion (paste excluded).
+  var text = changeObj.text;
+  if (!text || text.length !== 2 || text[0] !== '' || text[1] !== '') return;
+
+  // The line that was split is one above the cursor's current line.
+  var cursor = cm.getCursor();
+  var prevLineNo = cursor.line - 1;
+  if (prevLineNo < 0) return;
+
+  var prevLineText = cm.getLine(prevLineNo);
+  var continuation = continueListLine(prevLineText);
+  if (continuation === null) return;
+
+  state.continuingList = true;
+  setTimeout(function () {
+    cm.operation(function () {
+      if (continuation === '') {
+        // Termination: strip the empty marker from the previous line.
+        cm.replaceRange(
+          '',
+          { line: prevLineNo, ch: 0 },
+          { line: prevLineNo, ch: prevLineText.length },
+        );
+      } else {
+        // Continuation: insert the prefix at the cursor on the new line.
+        cm.replaceRange(continuation, cursor, cursor);
+      }
+    });
+    state.continuingList = false;
+  }, 0);
+}
+```
+
+- [ ] **Step 2: Run existing tests to verify no breakage**
+
+```bash
+npm test -- src/vim/list-continuation.test.js
+```
+
+Expected: All 23 tests still PASS (the new export doesn't affect them).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vim/list-continuation.js
+git commit -m "feat(list-continuation): add insert-mode change handler"
+```
+
+---
+
+## Task 2: Wire the handler into main.js
+
+**Files:**
+- Modify: `src/vim/index.js`
+- Modify: `src/main.js`
+
+- [ ] **Step 1: Re-export the handler from the barrel**
+
+Open `src/vim/index.js` and add (placement among the other exports doesn't matter, but keep it grouped near similar insert-mode handlers):
+
+```js
+export { handleListContinuation } from './list-continuation.js';
+```
+
+- [ ] **Step 2: Locate the existing change-event wiring in main.js**
+
+Use Grep to find the line:
+
+```
+pattern: handleTextwidthWrap|cm\.on\('change'
+path: src/main.js
+```
+
+Identify the change handler that calls `handleTextwidthWrap`. The new handler will be invoked alongside it.
+
+- [ ] **Step 3: Import and invoke the handler**
+
+In `src/main.js`:
+
+1. Add `handleListContinuation` to the import from `./vim/index.js`.
+2. In the same `cm.on('change', ...)` callback that calls `handleTextwidthWrap`, add a call to `handleListContinuation(cm, changeObj, state)`. Ensure `state` already carries `continuingList: false` at initialization (alongside `wrapping: false`). If it doesn't, add it.
+
+Example (illustrative — keep the existing structure intact):
+
+```js
+// In the state initialization (look for `wrapping: false`):
+var state = {
+  // ...existing fields...
+  wrapping: false,
+  continuingList: false,
+  // ...existing fields...
+};
+
+// In the change handler:
+cm.on('change', function (cm, changeObj) {
+  handleTextwidthWrap(cm, changeObj, state);
+  handleListContinuation(cm, changeObj, state);
+});
+```
+
+- [ ] **Step 4: Run the full check**
+
+```bash
+npm run check
+```
+
+Expected: lint clean, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vim/index.js src/main.js
+git commit -m "feat(list-continuation): wire insert-mode handler into editor"
+```
+
+---
+
+## Task 3: Document the feature on the help page
+
+**Files:**
+- Modify: `src/template.html`
+
+- [ ] **Step 1: Find a sensible location**
+
+Use Grep with pattern `textwidth|<h2>` on `src/template.html`. Find a section near existing markdown / insert-mode features, or place a new section before the "Persistence" heading.
+
+- [ ] **Step 2: Add documentation**
+
+Add an `<h2>` section like:
+
+```html
+<h2>List Continuation</h2>
+<p>
+  Pressing <kbd>Enter</kbd> in insert mode on a markdown list item
+  starts the next line with the same marker and indent. Numbered lists
+  increment automatically (<code>1.</code> &rarr; <code>2.</code>),
+  and task list checkboxes start unchecked. Pressing <kbd>Enter</kbd>
+  on an empty list marker terminates the list and leaves a blank
+  line.
+</p>
+<p>
+  Supported markers: <code>-</code>, <code>*</code>, <code>+</code>,
+  <code>1.</code> / <code>1)</code>, and GFM task lists
+  (<code>- [ ]</code> / <code>- [x]</code>).
+</p>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/template.html
+git commit -m "docs(help): document list continuation feature"
+```
+
+---
+
+## Task 4: Browser verification with Playwright
+
+**Files:** None (interactive verification).
+
+- [ ] **Step 1: Build and serve**
+
+```bash
+npm run build
+python3 -m http.server 9876 --bind 0.0.0.0
+```
+
+(Per `~/CLAUDE.md`: bind to `0.0.0.0` and reach it at `http://rika:9876/vi.html?test`.)
+
+- [ ] **Step 2: Drive Playwright through the test cases**
+
+Navigate to `http://rika:9876/vi.html?test`. For each scenario, set the document via `__vi.setDoc`, focus the editor, enter insert mode, and use Playwright's `pressSequentially` (per the CLAUDE.md note that insert-mode typing must use `pressSequentially`, not `__vi.pressKeys`):
+
+1. **Bullet continuation:** Set `''`, type `i- foo`, press Enter, type `bar`. Expected: doc is `- foo\n- bar`.
+2. **Ordered continuation + increment:** Set `''`, type `i1. foo`, press Enter, type `bar`. Expected: `1. foo\n2. bar`.
+3. **Multi-digit ordered:** Set `9. foo`, position cursor at end of line, type `i`, press Enter, type `bar`. Expected: `9. foo\n10. bar`.
+4. **Indented bullet:** Set `''`, type `i  - foo`, press Enter, type `bar`. Expected: `  - foo\n  - bar`.
+5. **Task list (unchecked):** Set `''`, type `i- [ ] task`, press Enter, type `next`. Expected: `- [ ] task\n- [ ] next`.
+6. **Task list (checked carries forward as unchecked):** Set `- [x] done`, position cursor at end, type `i`, press Enter, type `next`. Expected: `- [x] done\n- [ ] next`.
+7. **Termination:** Set `''`, type `i- foo`, press Enter, press Enter (empty marker). Expected: `- foo\n\n` and cursor on a blank line ready for normal text.
+8. **Non-list line:** Set `''`, type `iHello world`, press Enter, type `next`. Expected: `Hello world\nnext` (no marker injected).
+9. **Mid-line split:** Set `- foobar`, position cursor between `o` and `b` (at column 5), type `i`, press Enter. Expected: `- foo\n- bar`.
+
+- [ ] **Step 3: Verify no regressions in adjacent features**
+
+- Type a long sentence at `:set tw=40` &rarr; textwidth wrap still works.
+- Set `:ab teh the` then test &rarr; abbreviations still expand on space.
+- Press Enter in normal mode (not insert) &rarr; no continuation triggered.
+- Paste a multi-line block via clipboard or `__vi.setDoc` &rarr; no continuation injected into pasted lines.
+
+- [ ] **Step 4: Stop the server**
+
+Stop the python http.server with Ctrl-C.
+
+---
+
+## Task 5: Final lint, test, and verification gate
+
+- [ ] **Step 1: Run the full check that CI runs**
+
+```bash
+npm run check
+```
+
+Expected: lint and all tests pass.
+
+- [ ] **Step 2: Confirm the build still succeeds**
+
+```bash
+npm run build
+```
+
+Expected: `vi.html` builds without error.
+
+- [ ] **Step 3: Verify git state is clean**
+
+```bash
+git status
+```
+
+Expected: working tree clean (all earlier task commits already landed).
+
+---
+
+## Self-Review Checklist (filled out by the planner before handoff)
+
+- **Spec coverage:** Goal (auto-continue markdown lists with Enter, terminate on empty marker, preserve indent, increment ordered) — covered by Tasks 0 (function), 1 (handler), 2 (wiring). Help docs &mdash; Task 3. Browser verification &mdash; Task 4.
+- **Placeholder scan:** No "TBD"s, no "implement later"s, no "similar to Task N" without code.
+- **Type consistency:** `continueListLine` returns `string | null` consistently; `''` is the documented termination sentinel; `state.continuingList` name matches between Tasks 1 and 2.
+- **Project conventions honored:** TDD pattern (test first), pure-function-then-handler split (matches `textwidth.js`), `setTimeout(..., 0)` deferral (per CLAUDE.md CM6 dispatch gotcha), `Vim.defineOption`/Ex commands not introduced (always-on, YAGNI), help page updated (per CLAUDE.md custom-vim-feature requirement), browser verification step (per CLAUDE.md browser testing requirement).

--- a/docs/plans/2026-04-19-product-polish-roadmap.md
+++ b/docs/plans/2026-04-19-product-polish-roadmap.md
@@ -1,0 +1,105 @@
+# vi.html Product Polish Roadmap (April 2026)
+
+> **For Claude:** This is a multi-feature roadmap, not an executable plan. Each feature listed here gets its own dedicated implementation plan in `docs/plans/`. Pick a feature, write its plan with the `superpowers:writing-plans` skill, ship it, repeat. The roadmap itself is informational — there are no tasks to execute against it directly.
+
+## Vision
+
+vi.html is a single-file markdown editor for solo prose work — specifically the workflow of writing long documents (10–30 pages) in vim, then pasting clean HTML into Microsoft Word for final delivery. The target environment is a locked-down corporate machine where you can't install software but can open an HTML file in Edge.
+
+This roadmap captures the next round of product polish: features that make daily writing more pleasant, distinctive, and well-grounded in vim muscle memory.
+
+## Design North Star
+
+The aesthetic target is the world of *Her* (2013) crossed with Geoff McFetridge's design language — warm, calm, friendly, low-contrast but comfortable. A computer that's a friend, not a hacker tool. An oasis from corporate beige.
+
+Concretely:
+
+- Warm cream / parchment background; espresso text (not harsh black)
+- Terracotta or dusty-coral accents
+- Generous whitespace and line-height
+- Soft rounded forms; gentle easing on transitions
+- Rounded sans for chrome; an optional serif for the prose surface itself
+- Calm and deliberate, never aggressive
+
+## Architectural Commitments
+
+These are decided. Don't re-litigate.
+
+- **Stays a single static HTML file.** No backend, no telemetry, no WebSockets, no phone-home behavior. GitHub Pages deployment.
+- **Stack stays put.** CodeMirror 6 + `@replit/codemirror-vim` + `marked` is the foundation. We are not switching engines or rebuilding vim from scratch.
+- **"Nearest native browser feature" pattern.** Before reimplementing a vim feature, ask whether a browser-native equivalent achieves the goal. Spellcheck (`:set spell` → contenteditable `spellcheck` attribute, see `src/main.js:333`, `src/vim/options.js:63`) is the model.
+- **Smaller sequenced PRs.** One feature per branch per PR. No grand bundles.
+- **Test discipline.** Pure functions are exported and unit-tested. Browser behavior is verified interactively via the `?test` harness.
+
+## Reference Documents
+
+- **[Goerz vim quick reference card](https://michaelgoerz.net/refcards/vimqrc.pdf)** ([LaTeX source](https://github.com/goerz/Refcards/tree/master/vim)) — the canonical scope artifact for vim coverage. Used as a *negative* scope doc: every cell on the card is either already covered, in the feature inventory below, or in the explicit out-of-scope list. New "do we need feature X?" debates should start with "is X on the refcard?" and "is it already classified?"
+
+## Out of Scope, by Design
+
+These were considered and explicitly excluded. Add to this list as new "no" decisions get made — to stop us re-litigating later.
+
+- **Multi-windowing / window splits** (`:split`, `Ctrl-W` family). CM6 is one view; massive scope for marginal value.
+- **Tags** (`Ctrl-]`, `:tags`, `gd`/`gD`, `:ts`/`:tj`). No tag files in a browser.
+- **Compiling** (`:make`, `:compiler`, quickfix). No build pipeline.
+- **Shell** (`:sh`, `:!cmd`), `K` / `keywordprg`, `:hardcopy`. No shell.
+- **Real filesystem** (`:e file`, `:r file`, `gf`). Browser sandbox; partial coverage via the existing buffers system is enough.
+- **Completion frameworks** (`Ctrl-X Ctrl-*` family). Needs dictionaries / tags / etc.
+- **Differential testing infrastructure** (headless nvim oracle). Useful in theory; not worth the budget for this product's goals.
+- **Backend / accounts / collaboration.** Rails/Hetzner/Kamal explored and dropped for vi.html proper.
+- **Sharing features** (URL-fragment encoding, share-by-link). Irrelevant for the solo-use case.
+- **`formatoptions` flags.** Already documented as a known omission.
+
+## Feature Inventory
+
+Each feature below gets its own plan when it's time to build. Order is a recommendation, not a contract — the user picks the next one based on what they actually want.
+
+### Sprint 1 — Quick wins, prove the rhythm
+
+1. **Auto-continue lists** — Enter on `- foo` produces `- ` on the next line; `1.` becomes `2.`; preserves indent; Enter on empty marker terminates the list. Plan: `2026-04-19-list-continuation.md`.
+2. **Word count + reading time** — small status-bar indicator (one number, ~200 wpm reading-time estimate).
+
+### Sprint 2 — Foundational
+
+3. **Theme: the "Her" treatment** — warm cream/espresso palette, McFetridge sensibility. One opinionated theme, plus a same-aesthetic dark variant for late-night work. Will likely warrant a `-design.md` companion before the implementation plan.
+4. **Word-paste fidelity audit** — diagnostic pass: build representative test docs (headings, lists, tables, blockquotes, code spans, emphasis, curly quotes), paste into Word, fix anything ugly. May produce an explicit "Copy as Word-friendly HTML" command if helpful.
+
+### Sprint 3 — Long-doc tools
+
+5. **Outline / TOC pane** — `:TOC` or `gO` opens a navigable list of headings. Critical for 30-page docs.
+6. **Focus / typewriter mode** — dim non-active paragraphs; center current line. Toggle via `:focus` or similar.
+7. **Scroll-synced live preview** — editor and preview track each other while scrolling.
+
+### Sprint 4 — Vim power
+
+8. **Macros** (`q`/`@`/`@@`) — record and replay key sequences. Vim's killer feature for repetitive edits.
+9. **`:g`/`:v` global command** — run an Ex command on every line matching/not-matching a pattern. Examples: `:g/TODO/d`, `:v/^#/d`.
+
+### Sprint 5 — Backlog
+
+10. **Smart renumbering** — delete an item from `1. 2. 3.`, the rest renumber.
+11. **Autosave / persistence audit** — review localStorage save cadence, TTL, and whether to add an undo-across-reload snapshot ring.
+
+### Stretch — Markdown extras
+
+12. **GFM tables** — table editing helpers (auto-format, alignment, navigation).
+13. **Footnotes** — `[^1]` syntax in marked + smart insert helper.
+
+## Someday-Maybe (Parking Lot)
+
+These were filed for later, mostly because they belong to the *recipe editor* sister project, not vi.html proper.
+
+- **`cooleditor-rails` gem** — Stimulus controller wrapping the built bundle, importmap entry, configurable options. **Trigger:** after porting the vim layer into the recipe editor reveals real integration friction. **Anti-goal:** generalizing before we know what the API surface wants to be.
+- **Cooleditor.com platform with accounts** (Rails 8 on Hetzner via Kamal): server-side document storage, share-by-shortcode, collaborative editing (CRDT), server-side PDF export, GitHub OAuth. **Trigger:** a specific feature on the inventory above that genuinely cannot be done client-side. **Guardrail:** the single-file `vi.html` stays the flagship artifact; the platform is additive, never replaces it.
+
+## Process
+
+For each feature:
+
+1. Pick from the inventory.
+2. Write a detailed implementation plan: `docs/plans/YYYY-MM-DD-<feature-name>.md`. Use the `superpowers:writing-plans` skill.
+3. Commit the plan on a feature branch.
+4. Execute via `superpowers:subagent-driven-development` (per `~/CLAUDE.md`: skip the "subagent vs inline?" prompt and proceed directly with subagent-driven).
+5. Verification gate: `npm run check` clean + interactive browser test passes.
+6. Open the PR via `gh pr create` (standing permission per `~/CLAUDE.md` once the verification gate passes).
+7. After merge, update this roadmap to mark the feature shipped.


### PR DESCRIPTION
## Summary

- **Roadmap** (`docs/plans/2026-04-19-product-polish-roadmap.md`) — captures vision, design north star (*Her* + McFetridge), architectural commitments, explicit out-of-scope list, the [Goerz vim refcard](https://michaelgoerz.net/refcards/vimqrc.pdf) as the canonical scope artifact, and a 13-item feature inventory grouped into five sprints plus stretch goals and someday-maybe.
- **First feature plan** (`docs/plans/2026-04-19-list-continuation.md`) — auto-continue markdown lists in insert mode. Six TDD-disciplined tasks: pure function with 23 unit tests, change handler matching the `textwidth.js` pattern, wiring, help docs, nine Playwright scenarios, final lint/build gate.
- **`CLAUDE.md`** — adds a brief Git Workflow pointer (user-wide rules now live in `~/CLAUDE.md`) and a Roadmap & Reference Docs section that names the Goerz refcard as the negative scope doc.

## Scope intentionally NOT in this PR

- The user-wide `~/CLAUDE.md` got cribbed git/process rules from mirepoix (trunk-based workflow, GH-Issues-as-source-of-truth, Opus subagents). That file lives outside the repo and isn't included here.
- Auto-memory pointers were saved at `~/.claude/projects/-home-claude-vi-html/memory/` to give future sessions fast access to the workflow context, design north star, roadmap location, and refcard URL. Also outside the repo.
- No code changes. The first feature plan is ready to execute via subagent-driven development; that's a follow-up PR.

## Test plan

Docs-only — no automated tests apply. Manual review:
- [ ] Roadmap accurately reflects the conversation that produced it (vision, design, scope, sequencing)
- [ ] List-continuation plan is self-contained and bite-sized enough that a fresh subagent could pick it up cold
- [ ] CLAUDE.md additions read coherently against the rest of the file
- [ ] Goerz refcard URL resolves and matches what we discussed

🤖 Generated with [Claude Code](https://claude.com/claude-code)