### PR TITLE
docs: document CM6's native markdown list continuation (Option D pivot)

### DIFF
--- a/docs/plans/2026-04-19-list-continuation.md
+++ b/docs/plans/2026-04-19-list-continuation.md
@@ -1,5 +1,11 @@
 # Auto-Continue Lists Implementation Plan
 
+> **⚠ SUPERSEDED 2026-04-19.** This plan was partially executed (Tasks 0, 1, 2 were implemented and reviewed) before browser verification (Task 4) revealed that CM6 + `@codemirror/lang-markdown` already handles list continuation natively &mdash; bullets, ordered-with-increment, task-lists-carry-forward, and indent preservation all work without any custom code. Our custom handler was redundant for every continuation case, and its termination branch *conflicted* with CM6's continuation (producing `- foo\n\n- ` instead of the intended `- foo\n\n`). All three implementation commits were reverted. The only remaining artifact is the refined "List Continuation" section in the help page (`src/template.html`), which documents the already-working native behavior.
+>
+> **Lesson captured** in the roadmap's architectural commitments: *Verify native CM6 behavior before planning.* Drive scenarios through the `?test` harness before writing a plan that touches Enter/Backspace/Tab/cursor/selection semantics. CM6 does more than expected.
+>
+> Kept on disk as a record of the pivot. Do not execute.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** When pressing Enter in insert mode on a markdown list item, automatically begin the next line with the same marker, indent, and (for ordered lists) incremented number. Pressing Enter on an empty list marker terminates the list and leaves a blank line.

--- a/docs/plans/2026-04-19-product-polish-roadmap.md
+++ b/docs/plans/2026-04-19-product-polish-roadmap.md
@@ -28,6 +28,7 @@ These are decided. Don't re-litigate.
 - **Stays a single static HTML file.** No backend, no telemetry, no WebSockets, no phone-home behavior. GitHub Pages deployment.
 - **Stack stays put.** CodeMirror 6 + `@replit/codemirror-vim` + `marked` is the foundation. We are not switching engines or rebuilding vim from scratch.
 - **"Nearest native browser feature" pattern.** Before reimplementing a vim feature, ask whether a browser-native equivalent achieves the goal. Spellcheck (`:set spell` → contenteditable `spellcheck` attribute, see `src/main.js:333`, `src/vim/options.js:63`) is the model.
+- **Verify native CM6 behavior *before* planning.** Before writing a plan that adds Enter/Backspace/Tab/cursor/selection behavior, drive the existing editor through the target scenarios via the `?test` harness and record what already works. CM6 plus `@codemirror/lang-markdown` does more than expected &mdash; markdown list continuation (bullets, ordered-with-increment, task-lists-carry-forward, indent preservation) is fully native. Skipping this check once cost us an entire list-continuation feature branch (plan `2026-04-19-list-continuation.md`), which re-implemented already-working logic and introduced subtle bugs by layering on top of it. The lesson: the first task of any keymap-adjacent plan is a short empirical-survey task that documents current native behavior.
 - **Smaller sequenced PRs.** One feature per branch per PR. No grand bundles.
 - **Test discipline.** Pure functions are exported and unit-tested. Browser behavior is verified interactively via the `?test` harness.
 
@@ -56,7 +57,7 @@ Each feature below gets its own plan when it's time to build. Order is a recomme
 
 ### Sprint 1 — Quick wins, prove the rhythm
 
-1. **Auto-continue lists** — Enter on `- foo` produces `- ` on the next line; `1.` becomes `2.`; preserves indent; Enter on empty marker terminates the list. Plan: `2026-04-19-list-continuation.md`.
+1. ~~**Auto-continue lists**~~ — **Shipped (via CM6 native).** CM6 + `@codemirror/lang-markdown` already provides bullet, ordered-with-increment, task-list-unchecked-carry, and indent-preserving continuation. The only gap &mdash; empty-marker termination &mdash; proved not worth a custom override (see superseded plan `2026-04-19-list-continuation.md`). User-facing docs added in help page's "List Continuation" section.
 2. **Word count + reading time** — small status-bar indicator (one number, ~200 wpm reading-time estimate).
 
 ### Sprint 2 — Foundational

--- a/src/template.html
+++ b/src/template.html
@@ -39,6 +39,7 @@
             <li><a href="#s-copying-pasting">Copying &amp; Pasting</a></li>
             <li><a href="#s-text-objects">Text Objects</a></li>
             <li><a href="#s-working-with-prose">Working with Prose</a></li>
+            <li><a href="#s-list-continuation">List Continuation</a></li>
             <li><a href="#s-finding-replacing">Finding &amp; Replacing</a></li>
             <li><a href="#s-dot-command">The Dot Command</a></li>
             <li><a href="#s-undo-redo">Undo &amp; Redo</a></li>
@@ -580,6 +581,26 @@
             blank-line paragraph boundaries &mdash; it won&rsquo;t merge
             separate paragraphs.
           </div>
+
+          <h2 id="s-list-continuation">List Continuation</h2>
+          <p>
+            Pressing <kbd>Enter</kbd> in Insert mode on a markdown list item
+            starts the next line with the same marker and indent. Numbered lists
+            increment automatically (<code>1.</code> &rarr; <code>2.</code>),
+            and task-list checkboxes carry forward unchecked.
+          </p>
+          <p>
+            Supported markers: <code>-</code>, <code>*</code>, <code>+</code>,
+            <code>1.</code> / <code>1)</code>, and GFM task lists (<code
+              >- [ ]</code
+            >
+            / <code>- [x]</code>).
+          </p>
+          <p>
+            To exit a list, clear the empty marker with <kbd>Backspace</kbd>, or
+            press <kbd>Esc</kbd> to return to Normal mode and use
+            <kbd>dd</kbd> to remove the empty line.
+          </p>
 
           <h2 id="s-finding-replacing">Finding and Replacing</h2>
           <table>


### PR DESCRIPTION
## Summary

Branch originally implemented custom markdown list continuation (three commits, ~120 LOC: pure function, change handler, wiring). During browser verification with the `?test` harness, discovered that **CM6 + `@codemirror/lang-markdown` already handles list continuation natively** — bullets, ordered-with-increment, task-list-carry-forward-unchecked, indent-preservation, mid-line split, all working without any custom code.

Worse: the custom handler *fought* CM6 on empty-marker termination, producing `- foo\n\n- ` instead of the intended `- foo\n\n` because CM6 duplicated the marker on a new line while our handler stripped it from the old line.

Per user direction ("Option D"), the code commits were reverted and this PR keeps only the user-facing documentation of the already-working native behavior.

## What landed

- **`src/template.html`** — new "List Continuation" help section (plus TOC entry) describing the native behavior accurately: bullets continue, ordered lists increment, task lists carry forward unchecked. Honest note: empty-marker termination is **not** automatic; users clear the empty marker with Backspace or return to Normal mode and use `dd`.
- **`docs/plans/2026-04-19-product-polish-roadmap.md`** — new binding commitment under *Architectural Commitments*: **verify native CM6 behavior via the `?test` harness before planning any feature that touches Enter/Backspace/Tab/cursor/selection semantics.** The feature inventory's item #1 marked shipped-via-native with a pointer to the superseded plan.
- **`docs/plans/2026-04-19-list-continuation.md`** — superseded-header added capturing the full story: what we built, what we found, why it was reverted, what the lesson was. Kept on disk as a record, not deleted.

## What did NOT land

- No runtime code changes.
- No tests added or removed.
- No build output change beyond the help-page HTML.

## Test plan

- [x] `npm run check` — lint + 126 tests green
- [x] `npm run build` — `vi.html` builds cleanly (1567.5 KB)
- [ ] Browser smoke: visit the built page, confirm "List Continuation" shows up in the Help TOC and the section renders correctly
- [ ] Browser smoke: confirm Enter on `- foo` still continues (it does — that's CM6's native behavior, which this PR now documents)

## Lesson for the next session

Before writing any plan that adds Enter/Backspace/Tab/cursor/selection behavior, run the target scenarios through `window.__vi` in the `?test` harness and record what CM6 already does. The project now has a memory file (`cm6_native_coverage.md`) capturing today's discovery; update it as more native behavior is uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)