### PR TITLE
Theme: Paper & Clay (light) + Espresso Mirror (dark), OS-follow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 dist/
 vi.html
 .playwright-mcp/
+.superpowers/
 *.png

--- a/docs/plans/2026-04-19-theme-design.md
+++ b/docs/plans/2026-04-19-theme-design.md
@@ -1,0 +1,193 @@
+# Theme: the "Her" treatment — design
+
+**Status:** design, pending implementation plan
+**Date:** 2026-04-19
+**Roadmap item:** Sprint 2 #3 (`docs/plans/2026-04-19-product-polish-roadmap.md:65`)
+**Related commitment:** "Verify native CM6 behavior before planning" — the CM6 theming survey is folded in below as §0.
+
+## 0. CM6 theming surface — empirical survey
+
+Before designing, we surveyed what CM6 provides natively. Summary (full survey retained in session history):
+
+- `EditorView.theme(spec, { dark })` returns a scoped extension; selectors use `&` for the editor wrapper, `&dark`/`&light` to condition on the `darkTheme` facet. Multiple themes coexist by CSS order. Swap at runtime via `Compartment.reconfigure`.
+- `@codemirror/language` exports `HighlightStyle.define([{ tag, ...css }])` and `syntaxHighlighting(style)`. Per-theme styles are inlined at extension-creation time — **CSS variables cannot reach into `HighlightStyle`**; one style instance per theme is required.
+- `@lezer/markdown` emits per-level heading tags (`tags.heading1`–`heading6`), plus `emphasis`, `strong`, `link`, `url`, `monospace` (covers inline code + fenced-block text), `quote`, `list`, `processingInstruction` (list marks, heading `#`, emphasis marks), `contentSeparator` (HR). No dedicated tag for task-list checkboxes.
+- CM6 has no first-class OS dark-mode switch. `prefers-color-scheme` is host-side; the host feeds CM6.
+- **Current state of vi.html:** no syntax highlighting active in the editor today. `src/style.css:138–178` contains dead CM5-era `.cm-header`/`.cm-em` rules that CM6 does not emit. Palette lives in CSS variables at `src/style.css:1–19` but the values are a dark monospace-green scheme. Preview (`:262–387`) and help (`:389–628`) panes hardcode a light palette (~200 lines) independent of the editor. Two hardcoded hex exceptions inside the JS editor theme: `#4e5a8a` (tilde) at `src/main.js:208`, `#1e3a24` (focused selection) at `src/main.js:180`.
+
+## 1. Scope
+
+In scope:
+
+- Warm cream/espresso **light palette** ("Paper & Clay") across editor, preview, and help panes.
+- Matching **dark palette** ("Espresso Mirror") across the same surfaces.
+- **Markdown syntax highlighting** in the editor (not currently active).
+- **OS-follow** switching via `prefers-color-scheme`, both on initial load and on live OS change.
+- Deletion of dead CM5-era token CSS in `src/style.css`.
+
+Out of scope (explicit):
+
+- No manual theme-override Ex command (no `:colorscheme`, no `:set theme=`, no `:set background=`).
+- No persistence layer (OS is the source of truth).
+- No user-authored themes.
+- No additional named schemes beyond the two.
+- No task-list checkbox custom parser decoration (noted as an open item in §3).
+
+## 2. Architecture
+
+Three layers wired through one runtime control surface:
+
+1. **CSS custom-property palette.** Two `:root` variable blocks under `html[data-theme='light']` and `html[data-theme='dark']` in `src/style.css`. Every color in editor chrome, preview, and help panes is routed through variables.
+2. **Editor chrome theme.** The existing `EditorView.theme({...})` block in `src/main.js:148–213` stays mostly as-is; it already reads `var(--bg)`, `var(--fg)`, etc. Two hardcoded exceptions (`#4e5a8a`, `#1e3a24`) migrate to variables. This extension is static — never reconfigured at runtime.
+3. **Syntax highlighting.** A new module `src/vim/highlight.js` exports two `HighlightStyle` instances (one per theme) wrapped in `syntaxHighlighting(...)`. Hardcoded hex values per the palette in §3 (CSS variables cannot reach `HighlightStyle`). A `themeCompartment` in `main.js` holds the active variant and is reconfigured on OS change.
+4. **OS-follow switcher.** `matchMedia('(prefers-color-scheme: dark)')` listener in `main.js`: on initial read and on change, (a) set `document.documentElement.dataset.theme`, (b) `themeCompartment.reconfigure(activeHighlight)`.
+
+## 3. Palette specification
+
+Identical variable names across themes; different hex values.
+
+### Light — Paper & Clay (`html[data-theme='light']`)
+
+| Variable | Hex | Role |
+|---|---|---|
+| `--bg` | `#f4ede0` | Editor & app background (warm parchment) |
+| `--bg-elevated` | `#ebe2d2` | Status bar, tab bar, dialog backgrounds |
+| `--fg` | `#3d3530` | Primary text (espresso) |
+| `--fg-muted` | `#6b5d4f` | Status bar text, labels |
+| `--fg-faint` | `#987b5a` | Blockquote body, comments |
+| `--accent` | `#c4634d` | Clay-red — h1, links, emphasis, strong |
+| `--accent-soft` | `#b05d2b` | h2–h6 |
+| `--list-mark` | `#9a7540` | List bullets, ordered-list numerals |
+| `--code` | `#7a8f6e` | Inline code & fenced-block text (muted sage) |
+| `--tilde` | `#b89968` | End-of-buffer `~` (honey gold) |
+| `--rule` | `#c9b898` | Horizontal rules, subtle borders |
+| `--sel-bg` | `#e5d8bc` | Selection background |
+| `--cursor` | `#3d3530` | Block cursor |
+| `--active-line` | `rgba(61,53,48,0.04)` | Current-line highlight |
+
+### Dark — Espresso Mirror (`html[data-theme='dark']`)
+
+| Variable | Hex | Role |
+|---|---|---|
+| `--bg` | `#2a2320` | Editor & app background |
+| `--bg-elevated` | `#352b26` | Status bar, tab bar, dialogs |
+| `--fg` | `#e4d8c0` | Primary text |
+| `--fg-muted` | `#a89680` | Status bar text |
+| `--fg-faint` | `#9f8c74` | Blockquotes, comments |
+| `--accent` | `#e08060` | h1, links, emphasis, strong |
+| `--accent-soft` | `#d27458` | h2–h6 |
+| `--list-mark` | `#b89968` | Bullets, numerals |
+| `--code` | `#9bb08a` | Inline code & fenced blocks |
+| `--tilde` | `#7a6347` | End-of-buffer `~` |
+| `--rule` | `#4a3f37` | Horizontal rules, borders |
+| `--sel-bg` | `#4a3c30` | Selection background |
+| `--cursor` | `#e4d8c0` | Block cursor |
+| `--active-line` | `rgba(228,216,192,0.04)` | Current-line highlight |
+
+### Syntax highlighting token map
+
+Identical structure both themes; the hex resolves to the light or dark variant above.
+
+| Lezer tag | Color | Treatment |
+|---|---|---|
+| `heading1` | accent | Bold, base monospace size |
+| `heading2` – `heading6` | accent-soft | Bold, base monospace size |
+| `emphasis` | accent | Italic |
+| `strong` | accent | Bold |
+| `link`, `url` | accent | Regular weight |
+| `monospace` | code | Inline code + fenced-block body (no background pill) |
+| `quote` | fg-faint | Italic |
+| `list` (container) | inherit | Body text inside list items unchanged |
+| `processingInstruction` | list-mark | List markers, heading `#`, emphasis/strong marks |
+| `contentSeparator` | rule | Horizontal rules |
+
+**Design decisions:**
+
+- **Uniform heading size.** All headings render at base monospace size; hierarchy conveyed via color + weight only. Preserves vim's monospace grid (column counts, cursor navigation, `gq`/`gw` reflow visuals). Rendered preview pane conveys true size hierarchy via HTML.
+- **No code-span background pill.** Inline code is colored text on plain bg. Keeps horizontal monospace grid exact.
+
+**Open item (to resolve during implementation):** task-list checkboxes (`[ ]` / `[x]`) do not get a dedicated Lezer tag from `@lezer/markdown`. Two acceptable outcomes: (a) they inherit reasonable styling from `processingInstruction` + base text and we ship as-is, or (b) they need a custom parser decoration. If (b), that decoration is **out of scope** for this feature — defer to a follow-up. Implementation plan will verify and pick.
+
+## 4. Runtime behavior
+
+**On page load:**
+
+1. Read `matchMedia('(prefers-color-scheme: dark)').matches`.
+2. Set `document.documentElement.dataset.theme = matches ? 'dark' : 'light'`. CSS variables update → full app chrome colors correctly on first paint.
+3. Initialize `themeCompartment` with `syntaxHighlighting(matches ? darkHighlight : lightHighlight)`. Editor syntax tokens render correctly on first paint — no flash.
+
+**On OS theme change:**
+
+1. `matchMedia` change listener fires.
+2. Update `dataset.theme` → chrome recolors.
+3. `themeCompartment.reconfigure(newHighlight)` → editor tokens recolor.
+4. Instant, no easing. No cursor jump, no state loss, no reload.
+
+**Browsers without `prefers-color-scheme`:** `matches` returns `false`; light variant is the default. Acceptable.
+
+**Persistence:** none. OS is the single source of truth.
+
+## 5. Error handling
+
+The feature has no runtime failure modes worth handling. `matchMedia`, `EditorView.theme`, and `syntaxHighlighting` are pure configuration; if they throw the app is fundamentally broken with no recovery path.
+
+The one failure shape is a typo in a palette hex — a visual bug, caught at the screenshot-review stage in §6, not a runtime error. No try/catch, no fallbacks.
+
+## 6. Testing
+
+**Unit (Vitest), `src/vim/highlight.test.js` (new):**
+
+- Both light and dark `HighlightStyle` instances construct without error.
+- Each emits rules for every tag in the §3 token map.
+- Hex values in each match the palette spec verbatim (regression guard against silent drift).
+
+**Browser (Playwright + `?test` harness):**
+
+1. Serve `vi.html` locally, open `?test`.
+2. `__vi.setDoc(...)` a sample doc with h1–h6, emphasis, strong, a link, inline code, a fenced block, a list, a blockquote, a horizontal rule.
+3. Screenshot editor region.
+4. `emulateMedia({ colorScheme: 'dark' })`.
+5. Assert `html[data-theme] === 'dark'`.
+6. Screenshot again.
+7. Spot-check a known token via `getComputedStyle` (e.g. heading-line child span resolves to dark-accent hex).
+
+Screenshots go to `~/screenshots/` per `CLAUDE.md`. Pixel-perfect diffing is explicitly not used — human review of the pair is the decision surface.
+
+**PR verification gate:** `npm run check` green, `npm run build` green, light+dark screenshots attached.
+
+## 7. Implementation slices
+
+Five ordered slices, each a checkpoint. Every slice leaves the app working.
+
+| # | Scope | Files | Checkpoint |
+|---|---|---|---|
+| 1 | Palette variables + delete dead CSS | `src/style.css`, `src/main.js` (remove `#4e5a8a`, `#1e3a24`) | App looks like Paper & Clay; `dataset.theme = 'light'` set statically; no functional change; dark unreachable. |
+| 2 | Syntax highlighting (light only) | `src/vim/highlight.js` (new), `src/vim/highlight.test.js` (new), `src/main.js` | Editor shows markdown highlighting in Paper & Clay; static `syntaxHighlighting(...)` — no compartment yet. |
+| 3 | Dark palette variables | `src/style.css` | Dark variables defined; manual flip to `dataset.theme = 'dark'` renders chrome correctly; revert to `'light'` before commit. |
+| 4 | Dark highlight + compartment | `src/vim/highlight.js`, `src/main.js` | `themeCompartment` introduced; both highlight variants exist; reconfigure works when dispatched manually via `__vi.view`. Default still light. |
+| 5 | OS-follow switcher + help page update | `src/main.js`, `src/template.html` (help content) | `matchMedia` read + listener wired; OS flip recolors whole app live; help page documents the behavior. |
+
+**Not touched:** `src/storage.js`, `src/vim/exrc.js`, `src/vim/options.js`, `src/vim/commands.js`, any vim module outside the new `highlight.js`.
+
+**Estimated PR size:** ~300 lines net.
+
+## 8. Non-goals
+
+- Manual theme override / `:colorscheme` command. If added later, it's a separate feature with its own design.
+- User-authored theme files or imports.
+- Checked-in Playwright test suite in CI. §6 describes an interactive browser test; making it a CI-gated suite is a distinct polish item (candidate for a future roadmap backlog entry).
+- Custom parser decoration for task-list checkboxes (see §3 open item).
+
+## 9. References
+
+- Roadmap: `docs/plans/2026-04-19-product-polish-roadmap.md:65`
+- CM6 theming API: `node_modules/@codemirror/view/dist/index.d.ts:1367–1405`
+- `HighlightStyle`: `node_modules/@codemirror/language/dist/index.d.ts:831–935`
+- `@lezer/markdown` tag map: `node_modules/@lezer/markdown/dist/index.js:1952–1975`
+- `@lezer/highlight` tag catalog: `node_modules/@lezer/highlight/dist/index.d.ts:437–523`
+- Current editor theme: `src/main.js:148–213`
+- Current palette variables: `src/style.css:1–19`
+- Dead CM5-era CSS to delete: `src/style.css:138–178`
+- Preview pane CSS: `src/style.css:262–387`
+- Help pane CSS: `src/style.css:389–628`
+- Editor API pattern: `CLAUDE.md` (editorAPI / compartments)

--- a/docs/plans/2026-04-19-theme-design.md
+++ b/docs/plans/2026-04-19-theme-design.md
@@ -55,8 +55,11 @@ Identical variable names across themes; different hex values.
 | `--fg` | `#3d3530` | Primary text (espresso) |
 | `--fg-muted` | `#6b5d4f` | Status bar text, labels |
 | `--fg-faint` | `#987b5a` | Blockquote body, comments |
-| `--accent` | `#c4634d` | Clay-red — h1, links, emphasis, strong |
+| `--accent` | `#c4634d` | Clay-red — h1, links, emphasis, strong; status bar NORMAL mode |
 | `--accent-soft` | `#b05d2b` | h2–h6 |
+| `--accent-warm` | `#b88a3c` | Status bar INSERT mode (amber) |
+| `--accent-vis` | `#6b8094` | Status bar VISUAL mode (muted slate-blue) |
+| `--accent-rep` | `#9a3a2a` | Status bar REPLACE mode (deep crimson) |
 | `--list-mark` | `#9a7540` | List bullets, ordered-list numerals |
 | `--code` | `#7a8f6e` | Inline code & fenced-block text (muted sage) |
 | `--tilde` | `#b89968` | End-of-buffer `~` (honey gold) |
@@ -74,8 +77,11 @@ Identical variable names across themes; different hex values.
 | `--fg` | `#e4d8c0` | Primary text |
 | `--fg-muted` | `#a89680` | Status bar text |
 | `--fg-faint` | `#9f8c74` | Blockquotes, comments |
-| `--accent` | `#e08060` | h1, links, emphasis, strong |
+| `--accent` | `#e08060` | h1, links, emphasis, strong; status bar NORMAL mode |
 | `--accent-soft` | `#d27458` | h2–h6 |
+| `--accent-warm` | `#d4a35c` | Status bar INSERT mode (warm gold) |
+| `--accent-vis` | `#8ca3b8` | Status bar VISUAL mode (slate-blue) |
+| `--accent-rep` | `#c45a40` | Status bar REPLACE mode (saturated crimson) |
 | `--list-mark` | `#b89968` | Bullets, numerals |
 | `--code` | `#9bb08a` | Inline code & fenced blocks |
 | `--tilde` | `#7a6347` | End-of-buffer `~` |

--- a/docs/plans/2026-04-19-theme.md
+++ b/docs/plans/2026-04-19-theme.md
@@ -1,0 +1,1083 @@
+# Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the "Her treatment" theme — Paper & Clay (light) and Espresso Mirror (dark) palettes across editor/preview/help surfaces, markdown syntax highlighting (currently absent), and OS-follow switching via `prefers-color-scheme`.
+
+**Architecture:** CSS custom-property palettes keyed by `html[data-theme='light'|'dark']` drive all chrome. A new `src/vim/highlight.js` module exports two `HighlightStyle` instances (hardcoded hex; CSS variables cannot reach `HighlightStyle`) that a `themeCompartment` in `main.js` swaps on OS change. A `matchMedia('(prefers-color-scheme: dark)')` listener in `main.js` is the single switcher.
+
+**Tech Stack:** `@codemirror/language` (`HighlightStyle`, `syntaxHighlighting`, already installed), `@codemirror/state` (`Compartment`), `@replit/codemirror-vim`, `@lezer/highlight` (tag catalog).
+
+**Design doc:** `docs/plans/2026-04-19-theme-design.md` — palette tables live there. This plan cites them; do not copy palette values around.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/vim/highlight.js` — exports `lightHighlight`, `darkHighlight`, and `getHighlight(isDark)` returning `syntaxHighlighting(...)`. One responsibility: markdown token styling for both themes.
+- `src/vim/highlight.test.js` — asserts both styles construct, cover the expected tags, use the expected hex values.
+
+**Modify:**
+- `src/style.css` — replace `:root` palette with two `html[data-theme='...']` blocks (design doc §3); route preview (`:262–387`) and help (`:389–628`) panes through variables; delete dead CM5-era CSS (`:138–178`).
+- `src/main.js` — remove two hardcoded hex (`#1e3a24` at `:180`, `#4e5a8a` at `:208`) in favor of new variables; add `themeCompartment`; add `initial-theme` detection and `matchMedia` listener; export via `vim/index.js` barrel.
+- `src/vim/index.js` — re-export from new `highlight.js`.
+- `src/template.html` — add a help-page row documenting OS-follow theme behavior (near the `:set` options table or a new "Appearance" subsection).
+
+**Not touched:** `src/storage.js`, `src/vim/exrc.js`, `src/vim/options.js`, `src/vim/commands.js`, `src/vim/tilde.js`, `src/status.js`, `src/preview.js`, `build.js`, any existing `*.test.js`.
+
+---
+
+## Slice 1 — Light palette + delete dead CSS
+
+**Checkpoint goal:** App renders as Paper & Clay. `html[data-theme='light']` set statically. Every color referenced via CSS variables. Dead CM5-era rules removed. No syntax highlighting yet, no dark mode yet.
+
+### Task 1.1: Replace `:root` palette with light theme variable block
+
+**Files:**
+- Modify: `src/style.css:1–19`
+
+- [ ] **Step 1: Replace the `:root {...}` block at the top of `src/style.css`**
+
+Current `:root` (dark monospace green) is thrown out. Replace lines 1–19 with:
+
+```css
+:root {
+  /* Palette defaults to light; html[data-theme] selectors refine.
+     See docs/plans/2026-04-19-theme-design.md §3 for the full spec. */
+  color-scheme: light;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --bg: #f4ede0;
+  --bg-alt: #ebe2d2;
+  --bg-tab: #ebe2d2;
+  --fg: #3d3530;
+  --fg-dim: #6b5d4f;
+  --fg-faint: #987b5a;
+  --accent: #c4634d;
+  --accent-soft: #b05d2b;
+  --accent-warm: #b88a3c;
+  --accent-vis: #6b8094;
+  --accent-rep: #9a3a2a;
+  --list-mark: #9a7540;
+  --code: #7a8f6e;
+  --tilde: #b89968;
+  --rule: #c9b898;
+  --cursor-bg: #3d3530;
+  --tab-active: #e5d8bc;
+  --tab-border: #d4c8ae;
+  --status-bg: #ebe2d2;
+  --status-fg: #6b5d4f;
+  --flash-fg: #9a7540;
+  --sel-bg: #e5d8bc;
+  --dialog-bg: #ebe2d2;
+  --active-line: rgba(61, 53, 48, 0.04);
+}
+```
+
+Notes on variable mapping (design doc uses logical names; code uses existing names where possible):
+- `--bg-alt`, `--bg-tab`, `--dialog-bg`, `--status-bg` all map to design's `--bg-elevated` (#ebe2d2) — keep separate variable names so future tweaks can split them cheaply.
+- `--fg-dim` (existing) maps to design's `--fg-muted`. `--fg-faint` is new for blockquote body.
+- `--cursor-bg` (existing) maps to design's `--cursor`.
+
+- [ ] **Step 2: Set the initial `data-theme` attribute**
+
+Edit `src/template.html`. Find the opening `<html>` tag and change it to `<html data-theme="light">`. This guarantees first paint uses the right palette even before JS runs.
+
+- [ ] **Step 3: Build and verify no regressions from palette swap alone**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. The binary output changes size slightly; that's fine.
+
+- [ ] **Step 4: Visual sanity check**
+
+```bash
+python3 -m http.server 9876
+```
+
+Open `http://rika:9876/vi.html` in a browser. Every surface (editor, status bar, preview tab, help tab) should show warm parchment backgrounds and espresso text. Anything still dark-green is a missed hardcoded color — note it but don't fix yet; later tasks hunt them down.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/style.css src/template.html
+git commit -m "theme: swap palette to Paper & Clay (light)"
+```
+
+---
+
+### Task 1.2: Remove two hardcoded hex from editor theme
+
+**Files:**
+- Modify: `src/main.js:180` and `src/main.js:208`
+
+- [ ] **Step 1: Replace focused-selection hardcode at line 180**
+
+In `src/main.js`, find the block:
+
+```js
+'.cm-focused .cm-selectionBackground': {
+  backgroundColor: '#1e3a24 !important',
+},
+```
+
+Replace with:
+
+```js
+'.cm-focused .cm-selectionBackground': {
+  backgroundColor: 'var(--sel-bg) !important',
+},
+```
+
+Rationale: we no longer distinguish focused vs unfocused selection color — the palette has one `--sel-bg`. Focus state is conveyed by the cursor (which already disappears when unfocused).
+
+- [ ] **Step 2: Replace tilde color hardcode at line 208**
+
+In `src/main.js`, find:
+
+```js
+'.cm-tilde-line': {
+  color: '#4e5a8a',
+  fontSize: '17px',
+  lineHeight: '1.55',
+  paddingLeft: '6px',
+},
+```
+
+Replace with:
+
+```js
+'.cm-tilde-line': {
+  color: 'var(--tilde)',
+  fontSize: '17px',
+  lineHeight: '1.55',
+  paddingLeft: '6px',
+},
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green. No tests touch these lines; any failure is a regression elsewhere.
+
+- [ ] **Step 5: Visual check: tilde lines and selection look right**
+
+Reload `http://rika:9876/vi.html`. Create an empty buffer — tildes should render in honey gold (not the old slate-blue). Select some text — selection highlight should be the warm tan.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.js
+git commit -m "theme: route tilde and selection through CSS variables"
+```
+
+---
+
+### Task 1.3: Delete dead CM5-era token CSS
+
+**Files:**
+- Modify: `src/style.css:138–178`
+
+- [ ] **Step 1: Delete lines 138–178**
+
+These are CM5 class selectors (`.cm-header`, `.cm-strong`, `.cm-em`, `.cm-link`, `.cm-url`, `.cm-quote`, `.cm-comment`, `.cm-keyword`, `.cm-atom`, `.cm-string`, `.cm-variable-2`, `.cm-tag`) that CM6 does not emit. They have zero effect on the page. Survey confirmed via grep of `node_modules/@codemirror` — nothing produces these classes.
+
+Delete the block starting at `.cm-header {` and ending at the closing `}` of `.cm-tag`. Keep `.cm-searchMatch` at line 180 — that one is real (CM6 search emits it) and still wanted; update its background to a warm tone:
+
+```css
+.cm-searchMatch {
+  background: #e8d396;
+}
+```
+
+(The dark counterpart will come in Slice 3.)
+
+- [ ] **Step 2: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. Bundle shrinks slightly.
+
+- [ ] **Step 3: Visual confirmation nothing broke**
+
+Reload the browser. Editor should still render normally (no markdown tokens colored yet — that's Slice 2).
+
+- [ ] **Step 4: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/style.css
+git commit -m "theme: delete dead CM5-era token CSS"
+```
+
+---
+
+### Task 1.4: Route preview and help panes through variables
+
+**Files:**
+- Modify: `src/style.css` (post-deletion line numbers will shift; target the `/* ── Preview Pane ──` and `/* ── Help Pane ──` sections)
+
+- [ ] **Step 1: Replace preview pane hardcodes**
+
+In the `#preview-content` section (currently around line 262 pre-deletion; search for `Preview Pane`), every hardcoded hex needs to move to a variable. The preview currently hardcodes `#2a2a2a`, `#111`, `#1a1a1a`, `#222`, `#333`, `#f5f3ee`, `#eae7e0`, and similar. Replace per this mapping:
+
+| Current hex | Replace with | Role |
+|---|---|---|
+| `#2a2a2a` (body text) | `var(--fg)` | Body copy |
+| `#111`, `#1a1a1a`, `#222`, `#333` (headings) | `var(--fg)` | Preview headings inherit body color + get weight/size from existing rules |
+| `#f5f3ee`, `#eae7e0` (any bg tones) | `var(--bg)` or `var(--bg-alt)` per context | Preview bg |
+| Link color hardcode (if any) | `var(--accent)` | Rendered links |
+| Blockquote text color hardcode | `var(--fg-faint)` | Rendered blockquotes |
+| Code block bg/border | `var(--bg-alt)` + `var(--rule)` | Fenced code in preview |
+| HR color | `var(--rule)` | Rendered `---` |
+
+Read the block before editing — some rules don't need color changes. Work top-down through the preview section; every color property gets resolved.
+
+- [ ] **Step 2: Replace help pane hardcodes**
+
+Same approach for `/* ── Help Pane ──` onward. The help pane has its own set of hardcoded color rules that need routing through the same variables. Apply the same table.
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Visual check both panes**
+
+Reload. Click into the Preview tab (via `\p` or however tabs switch) — the rendered HTML should be parchment background with espresso text, clay-red links. Click the Help tab — same palette. Nothing should still look like the old dark-green scheme.
+
+- [ ] **Step 5: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/style.css
+git commit -m "theme: route preview and help panes through CSS variables"
+```
+
+---
+
+## Slice 2 — Syntax highlighting (light only)
+
+**Checkpoint goal:** Editor displays markdown syntax highlighting in Paper & Clay. A static `syntaxHighlighting(lightHighlight)` wired in — no compartment, no dark path yet.
+
+### Task 2.1: Create the highlight module with light variant
+
+**Files:**
+- Create: `src/vim/highlight.js`
+
+- [ ] **Step 1: Write `src/vim/highlight.js`**
+
+```js
+/**
+ * Markdown syntax highlighting for Paper & Clay (light) and Espresso Mirror (dark).
+ *
+ * HighlightStyle inlines its styles at creation time, so CSS variables cannot
+ * reach into the generated CSS. Hex values are hardcoded per
+ * docs/plans/2026-04-19-theme-design.md §3; keep both tables in sync.
+ */
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+/**
+ * Paper & Clay (light) highlight.
+ */
+export const lightHighlight = HighlightStyle.define([
+  { tag: t.heading1, color: '#c4634d', fontWeight: 'bold' },
+  { tag: t.heading2, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading3, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading4, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading5, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading6, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.emphasis, color: '#c4634d', fontStyle: 'italic' },
+  { tag: t.strong, color: '#c4634d', fontWeight: 'bold' },
+  { tag: t.link, color: '#c4634d' },
+  { tag: t.url, color: '#c4634d' },
+  { tag: t.monospace, color: '#7a8f6e' },
+  { tag: t.quote, color: '#987b5a', fontStyle: 'italic' },
+  { tag: t.processingInstruction, color: '#9a7540' },
+  { tag: t.contentSeparator, color: '#c9b898' },
+]);
+
+/**
+ * Espresso Mirror (dark) highlight. Filled in Slice 4.
+ */
+export const darkHighlight = null; // populated in Slice 4
+
+/**
+ * Returns a syntax-highlighting extension for the requested variant.
+ * `isDark` true → dark, false → light.
+ */
+export function getHighlight(isDark) {
+  return syntaxHighlighting(isDark ? darkHighlight : lightHighlight);
+}
+```
+
+Note the deliberate `null` for `darkHighlight` — Slice 4 fills it in. Until then, do not call `getHighlight(true)`.
+
+- [ ] **Step 2: Re-export from `src/vim/index.js`**
+
+Open `src/vim/index.js`. Add an export line in the same style as existing barrel exports (e.g., `export * from './tilde.js';`):
+
+```js
+export * from './highlight.js';
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vim/highlight.js src/vim/index.js
+git commit -m "theme: add highlight module with Paper & Clay tokens"
+```
+
+---
+
+### Task 2.2: Write unit tests for the light variant
+
+**Files:**
+- Create: `src/vim/highlight.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+/**
+ * Markdown syntax highlighting — palette spec regression guard.
+ * See docs/plans/2026-04-19-theme-design.md §3 for the palette spec.
+ */
+import { describe, test, expect } from 'vitest';
+import { tags as t } from '@lezer/highlight';
+import { lightHighlight } from './highlight.js';
+
+describe('lightHighlight (Paper & Clay)', () => {
+  test('constructs without error', () => {
+    expect(lightHighlight).toBeTruthy();
+  });
+
+  // A HighlightStyle exposes its raw spec via the `specs` property.
+  // If that API ever changes, these tests will break loudly — which is
+  // the point of a regression guard.
+  const specs = lightHighlight.specs;
+
+  function specFor(tag) {
+    return specs.find((s) => {
+      const tags = Array.isArray(s.tag) ? s.tag : [s.tag];
+      return tags.includes(tag);
+    });
+  }
+
+  test('heading1 is clay red, bold', () => {
+    const s = specFor(t.heading1);
+    expect(s).toBeDefined();
+    expect(s.color).toBe('#c4634d');
+    expect(s.fontWeight).toBe('bold');
+  });
+
+  test('heading2–heading6 are accent-soft, bold', () => {
+    for (const tag of [t.heading2, t.heading3, t.heading4, t.heading5, t.heading6]) {
+      const s = specFor(tag);
+      expect(s).toBeDefined();
+      expect(s.color).toBe('#b05d2b');
+      expect(s.fontWeight).toBe('bold');
+    }
+  });
+
+  test('emphasis is italic accent', () => {
+    const s = specFor(t.emphasis);
+    expect(s.color).toBe('#c4634d');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('strong is bold accent', () => {
+    const s = specFor(t.strong);
+    expect(s.color).toBe('#c4634d');
+    expect(s.fontWeight).toBe('bold');
+  });
+
+  test('link and url are accent', () => {
+    expect(specFor(t.link).color).toBe('#c4634d');
+    expect(specFor(t.url).color).toBe('#c4634d');
+  });
+
+  test('monospace is sage', () => {
+    expect(specFor(t.monospace).color).toBe('#7a8f6e');
+  });
+
+  test('quote is fg-faint, italic', () => {
+    const s = specFor(t.quote);
+    expect(s.color).toBe('#987b5a');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('processingInstruction is list-mark', () => {
+    expect(specFor(t.processingInstruction).color).toBe('#9a7540');
+  });
+
+  test('contentSeparator is rule', () => {
+    expect(specFor(t.contentSeparator).color).toBe('#c9b898');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+npm test -- src/vim/highlight.test.js
+```
+
+Expected: all tests pass (the module already exists from Task 2.1 with correct values).
+
+If the `specs` property turns out not to exist on the returned `HighlightStyle` (the CM6 API surface is lightly documented), adapt the test to probe whatever property holds the rule list. A quick `console.log(Object.keys(lightHighlight))` in a scratch test will reveal it. Whatever the property name, the principle is: iterate the constructed rules and assert each expected tag has its expected hex/weight/style.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vim/highlight.test.js
+git commit -m "theme: test Paper & Clay highlight tokens"
+```
+
+---
+
+### Task 2.3: Wire the light highlight into the editor
+
+**Files:**
+- Modify: `src/main.js`
+
+- [ ] **Step 1: Import the getter**
+
+In `src/main.js`, find the import block from `./vim/index.js` (around line 17). Add `getHighlight` to the imported names:
+
+```js
+import {
+  // ...existing names, keep as-is...
+  getHighlight,
+} from './vim/index.js';
+```
+
+- [ ] **Step 2: Add the extension to the EditorState**
+
+Find the `extensions: [...]` array in the `EditorState.create({...})` call (search for `EditorState.create`). Add `getHighlight(false)` to that array, placed near other syntax-related extensions (close to `markdown()`). For example, if the array has:
+
+```js
+extensions: [
+  // ...
+  markdown(),
+  // ...
+]
+```
+
+Change to:
+
+```js
+extensions: [
+  // ...
+  markdown(),
+  getHighlight(false),
+  // ...
+]
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Visual check — syntax highlighting alive**
+
+Reload `http://rika:9876/vi.html`. Load a markdown doc containing headings, `*em*`, `**strong**`, a link, `` `code` ``, a blockquote, a list, and `---`. The tokens should now render in the Paper & Clay palette: h1 clay-red, h2–h6 warmer orange, emphasis italic clay-red, strong bold clay-red, code sage green, blockquote italic muted-brown, list markers honey-gold, HR subtle tan.
+
+- [ ] **Step 5: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.js
+git commit -m "theme: wire Paper & Clay syntax highlighting"
+```
+
+---
+
+## Slice 3 — Dark palette variables
+
+**Checkpoint goal:** `html[data-theme='dark']` palette defined with Espresso Mirror hexes. Manually flipping `document.documentElement.dataset.theme = 'dark'` from the browser console renders the whole app chrome (editor, preview, help) in dark. No switcher yet; no dark syntax tokens yet.
+
+### Task 3.1: Add dark variable block
+
+**Files:**
+- Modify: `src/style.css`
+
+- [ ] **Step 1: Add a `html[data-theme='dark'] { ... }` block**
+
+Immediately after the `html[data-theme='light']` block you wrote in Task 1.1, add:
+
+```css
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #2a2320;
+  --bg-alt: #352b26;
+  --bg-tab: #352b26;
+  --fg: #e4d8c0;
+  --fg-dim: #a89680;
+  --fg-faint: #9f8c74;
+  --accent: #e08060;
+  --accent-soft: #d27458;
+  --accent-warm: #d4a35c;
+  --accent-vis: #8ca3b8;
+  --accent-rep: #c45a40;
+  --list-mark: #b89968;
+  --code: #9bb08a;
+  --tilde: #7a6347;
+  --rule: #4a3f37;
+  --cursor-bg: #e4d8c0;
+  --tab-active: #4a3c30;
+  --tab-border: #4a3f37;
+  --status-bg: #352b26;
+  --status-fg: #a89680;
+  --flash-fg: #b89968;
+  --sel-bg: #4a3c30;
+  --dialog-bg: #352b26;
+  --active-line: rgba(228, 216, 192, 0.04);
+}
+```
+
+- [ ] **Step 2: Add dark variant for the search match highlight**
+
+The light search-match background you set in Task 1.3 needs a dark counterpart. Add this rule below the existing `.cm-searchMatch` block in `style.css`:
+
+```css
+html[data-theme='dark'] .cm-searchMatch {
+  background: #5a4a28;
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual dark-mode smoke test**
+
+Reload the browser. Open DevTools → Console. Run:
+
+```js
+document.documentElement.dataset.theme = 'dark'
+```
+
+The entire app chrome should recolor to Espresso Mirror instantly. Click through editor / preview / help tabs; every surface should be warm dark. Syntax tokens in the editor will still be in the LIGHT palette (slice 4 fixes this) — note but ignore.
+
+Flip back to light:
+
+```js
+document.documentElement.dataset.theme = 'light'
+```
+
+Should recolor back. No errors in the console.
+
+- [ ] **Step 5: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/style.css
+git commit -m "theme: add Espresso Mirror (dark) palette variables"
+```
+
+---
+
+## Slice 4 — Dark syntax highlighting + compartment
+
+**Checkpoint goal:** `darkHighlight` module export populated. A `themeCompartment` in `main.js` holds the active variant. Reconfiguring it from the console correctly recolors editor tokens. OS-follow switcher is NOT wired yet — theme still statically light on load.
+
+### Task 4.1: Populate `darkHighlight`
+
+**Files:**
+- Modify: `src/vim/highlight.js`
+
+- [ ] **Step 1: Replace the `darkHighlight = null` stub**
+
+In `src/vim/highlight.js`, replace:
+
+```js
+export const darkHighlight = null; // populated in Slice 4
+```
+
+with:
+
+```js
+export const darkHighlight = HighlightStyle.define([
+  { tag: t.heading1, color: '#e08060', fontWeight: 'bold' },
+  { tag: t.heading2, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading3, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading4, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading5, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading6, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.emphasis, color: '#e08060', fontStyle: 'italic' },
+  { tag: t.strong, color: '#e08060', fontWeight: 'bold' },
+  { tag: t.link, color: '#e08060' },
+  { tag: t.url, color: '#e08060' },
+  { tag: t.monospace, color: '#9bb08a' },
+  { tag: t.quote, color: '#9f8c74', fontStyle: 'italic' },
+  { tag: t.processingInstruction, color: '#b89968' },
+  { tag: t.contentSeparator, color: '#4a3f37' },
+]);
+```
+
+- [ ] **Step 2: Extend the tests to cover `darkHighlight`**
+
+Append to `src/vim/highlight.test.js`:
+
+```js
+import { darkHighlight } from './highlight.js';
+
+describe('darkHighlight (Espresso Mirror)', () => {
+  test('constructs without error', () => {
+    expect(darkHighlight).toBeTruthy();
+  });
+
+  const specs = darkHighlight.specs;
+  function specFor(tag) {
+    return specs.find((s) => {
+      const tags = Array.isArray(s.tag) ? s.tag : [s.tag];
+      return tags.includes(tag);
+    });
+  }
+
+  test('heading1 is dark accent, bold', () => {
+    const s = specFor(t.heading1);
+    expect(s.color).toBe('#e08060');
+    expect(s.fontWeight).toBe('bold');
+  });
+
+  test('heading2–heading6 are accent-soft, bold', () => {
+    for (const tag of [t.heading2, t.heading3, t.heading4, t.heading5, t.heading6]) {
+      expect(specFor(tag).color).toBe('#d27458');
+      expect(specFor(tag).fontWeight).toBe('bold');
+    }
+  });
+
+  test('emphasis is italic accent', () => {
+    const s = specFor(t.emphasis);
+    expect(s.color).toBe('#e08060');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('strong is bold accent', () => {
+    expect(specFor(t.strong).color).toBe('#e08060');
+    expect(specFor(t.strong).fontWeight).toBe('bold');
+  });
+
+  test('link and url are accent', () => {
+    expect(specFor(t.link).color).toBe('#e08060');
+    expect(specFor(t.url).color).toBe('#e08060');
+  });
+
+  test('monospace is dark sage', () => {
+    expect(specFor(t.monospace).color).toBe('#9bb08a');
+  });
+
+  test('quote is fg-faint, italic', () => {
+    const s = specFor(t.quote);
+    expect(s.color).toBe('#9f8c74');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('processingInstruction is list-mark', () => {
+    expect(specFor(t.processingInstruction).color).toBe('#b89968');
+  });
+
+  test('contentSeparator is rule', () => {
+    expect(specFor(t.contentSeparator).color).toBe('#4a3f37');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- src/vim/highlight.test.js
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vim/highlight.js src/vim/highlight.test.js
+git commit -m "theme: populate Espresso Mirror (dark) highlight tokens"
+```
+
+---
+
+### Task 4.2: Swap static `getHighlight(false)` for a compartment
+
+**Files:**
+- Modify: `src/main.js`
+
+- [ ] **Step 1: Declare the compartment**
+
+In `src/main.js`, find the block of compartment declarations (around line 65–72, next to `lineNumbersCompartment`, `spellcheckCompartment`, etc.). Add:
+
+```js
+var themeCompartment = new Compartment();
+```
+
+- [ ] **Step 2: Replace the static extension with a compartmented one**
+
+Find the line added in Task 2.3 (`getHighlight(false)` in the `extensions: [...]` array). Replace with:
+
+```js
+themeCompartment.of(getHighlight(false)),
+```
+
+Default remains light; Slice 5 changes the initial argument to match the OS preference.
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual compartment smoke test**
+
+The test harness exposes `__vi.view`, `__vi.editorAPI`, and company. Serve with `?test` and load with sample markdown, then in the browser console:
+
+```js
+__vi.view.dispatch({
+  effects: __vi.view.state.values[X].reconfigure(__vi.getHighlight ?? null)
+})
+```
+
+That probe is fragile because compartments aren't currently exposed on `editorAPI`. The cleaner approach is: add a tiny debug affordance on `editorAPI` just for this slice's manual smoke test, OR skip the manual probe and let Slice 5's end-to-end test cover it. **Recommendation: skip the probe here.** The compartment is inert until Slice 5's listener fires, and full verification happens there. This step exists only to confirm the build still works.
+
+- [ ] **Step 5: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.js
+git commit -m "theme: hold highlight in a compartment for runtime swap"
+```
+
+---
+
+## Slice 5 — OS-follow switcher + help page
+
+**Checkpoint goal:** The app detects `prefers-color-scheme` on load, sets `data-theme` accordingly, and initializes the compartment with the matching highlight. A `matchMedia` change listener flips everything live when the OS switches. Help page documents the behavior. Feature-complete.
+
+### Task 5.1: Wire the initial theme and the change listener
+
+**Files:**
+- Modify: `src/main.js`
+
+- [ ] **Step 1: Add a helper and the initial read**
+
+Near the top of `src/main.js`, after the imports, before the `state` object (around line 55), add:
+
+```js
+// ── Theme: OS-follow via prefers-color-scheme ──────────
+var darkModeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+
+function applyTheme(isDark) {
+  document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
+}
+
+// Apply initial theme before the EditorView is constructed so first paint matches.
+applyTheme(darkModeMedia.matches);
+```
+
+- [ ] **Step 2: Seed the compartment with the OS-matching variant**
+
+Find the `themeCompartment.of(getHighlight(false))` line added in Task 4.2. Change the argument:
+
+```js
+themeCompartment.of(getHighlight(darkModeMedia.matches)),
+```
+
+- [ ] **Step 3: Wire the change listener**
+
+After the EditorView is constructed (near the end of the file, after `var view = new EditorView({...})` and related wiring — a sensible spot is right after the test harness install), add:
+
+```js
+// Live-update on OS theme change.
+darkModeMedia.addEventListener('change', function (e) {
+  applyTheme(e.matches);
+  view.dispatch({
+    effects: themeCompartment.reconfigure(getHighlight(e.matches)),
+  });
+});
+```
+
+- [ ] **Step 4: Remove the static `data-theme="light"` attribute from template.html**
+
+The attribute set in Task 1.1 Step 2 is now redundant — `applyTheme` writes it on load. Remove the `data-theme="light"` from the `<html>` tag in `src/template.html` (leave a bare `<html>`). This prevents a one-frame flash of wrong palette on a machine in OS dark mode when the browser paints HTML before running JS.
+
+Actually: keep the `data-theme="light"` in `template.html`. It's a safe fallback — if JS fails to load for any reason, the app remains usable in light mode. `applyTheme` immediately overwrites it on first JS execution. No flash risk because JS runs before first paint in normal load order.
+
+*(Leave the attribute as-is. This step is a no-op, retained as a decision anchor.)*
+
+- [ ] **Step 5: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Manual end-to-end verification**
+
+Serve `vi.html` and open in a browser. Put the OS into light mode → reload → everything is Paper & Clay, including editor syntax tokens.
+
+Flip OS to dark mode (macOS: System Settings → Appearance → Dark; Linux: depends on DE; can be simulated with DevTools: toggle device toolbar → more options → Rendering → "Emulate CSS prefers-color-scheme: dark"). The app should recolor LIVE without reloading: chrome, preview, help, and editor syntax tokens all flip.
+
+Flip back. Live flip the other way. Cursor should not jump, document content unchanged.
+
+- [ ] **Step 7: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main.js
+git commit -m "theme: OS-follow via prefers-color-scheme, live on change"
+```
+
+---
+
+### Task 5.2: Document theme behavior in the help page
+
+**Files:**
+- Modify: `src/template.html`
+
+- [ ] **Step 1: Find an insertion point**
+
+In `src/template.html`, locate the "Defaults that differ from vim" tip block (search for `Defaults that differ from vim`, around line 1011). Immediately after that `<div class="tip">…</div>`, add a new block:
+
+```html
+<div class="tip">
+  <b>Appearance:</b> vi.html follows your operating system&rsquo;s
+  light/dark mode preference automatically. Change your OS appearance
+  and the editor recolors immediately &mdash; no reload, no setting.
+</div>
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Visual confirmation**
+
+Reload, open the Help tab, scroll to the `:set` options section, confirm the new tip paragraph is present and legible in both palettes (flip the OS mid-read).
+
+- [ ] **Step 4: Lint + test**
+
+```bash
+npm run check
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/template.html
+git commit -m "theme: document OS-follow behavior in help page"
+```
+
+---
+
+### Task 5.3: Final browser-test pass with screenshots
+
+This is the PR verification gate per the design doc §6.
+
+- [ ] **Step 1: Build**
+
+```bash
+npm run build
+python3 -m http.server 9876 &
+```
+
+- [ ] **Step 2: Drive via Playwright**
+
+Navigate to `http://rika:9876/vi.html?test`. Paste this multi-feature sample into the editor (via the harness or manually) to exercise every highlighted token:
+
+```markdown
+# H1: Top heading
+## H2: Sub
+### H3: sub-sub
+
+Regular text with *emphasis*, **strong**, and a [link](https://example.com).
+
+Autolink: <https://example.com>
+
+Inline `code span` here.
+
+- bullet one
+- bullet two
+  - nested
+
+1. ordered one
+2. ordered two
+
+> A blockquote.
+> Second line.
+
+---
+
+```bash
+echo "fenced block"
+```
+```
+
+- [ ] **Step 3: Screenshot light mode**
+
+With OS (or Playwright `emulateMedia({ colorScheme: 'light' })`) in light, screenshot the editor region, the preview pane, and the help tab. Save to `~/screenshots/theme-light-editor.png`, `theme-light-preview.png`, `theme-light-help.png`.
+
+- [ ] **Step 4: Screenshot dark mode**
+
+`emulateMedia({ colorScheme: 'dark' })`. Verify `document.documentElement.dataset.theme === 'dark'` via `page.evaluate`. Screenshot the same three surfaces to `~/screenshots/theme-dark-*.png`.
+
+- [ ] **Step 5: Verify computed token colors**
+
+In Playwright, evaluate `getComputedStyle` on a heading line to confirm tokens resolved to the expected hex. Example:
+
+```js
+page.evaluate(() => {
+  const headingEl = document.querySelector('.cm-line .tok-heading1')
+                 ?? document.querySelector('.cm-line > span[style*="color"]');
+  return getComputedStyle(headingEl).color;
+});
+```
+
+Expect `rgb(224, 128, 96)` in dark (= `#e08060`).
+
+- [ ] **Step 6: Final `npm run check` + build**
+
+```bash
+npm run check
+npm run build
+```
+
+Expected: both green.
+
+- [ ] **Step 7: Push the branch and open the PR**
+
+```bash
+git push -u origin feature/theme
+gh pr create --title "Theme: Paper & Clay (light) + Espresso Mirror (dark), OS-follow" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements Sprint 2 roadmap item #3: the "Her" treatment theme.
+
+- **Light (Paper & Clay)** — warm parchment + espresso + clay-red accent.
+- **Dark (Espresso Mirror)** — same family, lamp-lit.
+- **OS-follow** via `prefers-color-scheme`; no manual override, no persistence (OS is the source of truth).
+- Ships the **markdown syntax highlighting** that was silently missing from the editor (the CM5-era token CSS at `src/style.css:138–178` was dead rules CM6 never emits — deleted).
+
+Design doc: `docs/plans/2026-04-19-theme-design.md`
+Implementation plan: `docs/plans/2026-04-19-theme.md`
+
+## Test plan
+
+- [x] `npm run check` green
+- [x] `npm run build` green
+- [x] Unit tests cover both `HighlightStyle` variants (hex regression guard)
+- [x] Light-mode screenshots attached (editor, preview, help)
+- [x] Dark-mode screenshots attached (editor, preview, help)
+- [x] Live OS-theme flip exercises the `matchMedia` change path; no reload, no cursor jump
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" --draft
+```
+
+Attach the six screenshots to the PR via the GitHub UI after creation.
+
+---
+
+## Out of scope (reference)
+
+Pulled forward from design doc §1 / §8 — do not expand this plan to include:
+
+- Manual `:colorscheme` / `:set theme=` Ex commands.
+- Persistence of a theme override (no localStorage, no exrc).
+- User-authored themes.
+- Additional named schemes.
+- Custom parser decoration for task-list checkbox `[ ]` / `[x]` — if the default highlighting looks odd in the visual pass, file a follow-up issue, do not fix here.
+- A checked-in Playwright test suite in CI — separate polish item.

--- a/src/build.test.js
+++ b/src/build.test.js
@@ -21,6 +21,6 @@ describe('build', () => {
     expect(html).toContain('EditorView');
 
     // Should contain bundled CSS (from style.css)
-    expect(html).toContain('.cm-header');
+    expect(html).toContain('.cm-searchMatch');
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -177,7 +177,7 @@ var view = new EditorView({
           backgroundColor: 'var(--sel-bg) !important',
         },
         '.cm-focused .cm-selectionBackground': {
-          backgroundColor: '#1e3a24 !important',
+          backgroundColor: 'var(--sel-bg) !important',
         },
         '.cm-panels': {
           backgroundColor: 'var(--dialog-bg)',
@@ -205,7 +205,7 @@ var view = new EditorView({
           userSelect: 'none',
         },
         '.cm-tilde-line': {
-          color: '#4e5a8a',
+          color: 'var(--tilde)',
           fontSize: '17px',
           lineHeight: '1.55',
           paddingLeft: '6px',

--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,7 @@ var indentUnitCompartment = new Compartment();
 var abbreviationsCompartment = new Compartment();
 var spellcheckCompartment = new Compartment();
 var foldGutterCompartment = new Compartment();
+var themeCompartment = new Compartment();
 
 // Track current values for settings display (compartment.get() is unreliable)
 var currentLineNumbers = true;
@@ -118,7 +119,7 @@ var view = new EditorView({
       tabSizeCompartment.of(EditorState.tabSize.of(4)),
       indentUnitCompartment.of(indentUnitFacet.of('    ')),
       markdown(),
-      getHighlight(false),
+      themeCompartment.of(getHighlight(false)),
       history(),
       bracketMatching(),
       drawSelection(),

--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,7 @@ import {
   foldGutterExtension,
   registerFoldCommands,
   registerClipboard,
+  getHighlight,
 } from './vim/index.js';
 import { installTestHarness } from './test-harness.js';
 
@@ -117,6 +118,7 @@ var view = new EditorView({
       tabSizeCompartment.of(EditorState.tabSize.of(4)),
       indentUnitCompartment.of(indentUnitFacet.of('    ')),
       markdown(),
+      getHighlight(false),
       history(),
       bracketMatching(),
       drawSelection(),

--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,15 @@ import {
 } from './vim/index.js';
 import { installTestHarness } from './test-harness.js';
 
+// ── Theme: OS-follow via prefers-color-scheme ──────────
+var darkModeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+
+function applyTheme(isDark) {
+  document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
+}
+
+applyTheme(darkModeMedia.matches);
+
 // ── Application state ───────────────────────────────────
 var state = {
   textwidth: 0,
@@ -119,7 +128,7 @@ var view = new EditorView({
       tabSizeCompartment.of(EditorState.tabSize.of(4)),
       indentUnitCompartment.of(indentUnitFacet.of('    ')),
       markdown(),
-      themeCompartment.of(getHighlight(false)),
+      themeCompartment.of(getHighlight(darkModeMedia.matches)),
       history(),
       bracketMatching(),
       drawSelection(),
@@ -477,6 +486,14 @@ executeExrc(cm);
 
 // ── Test harness (vi.html?test) ──────────────────────────
 installTestHarness(view, cm, state, editorAPI);
+
+// ── Theme: react to OS color-scheme changes ─────────────
+darkModeMedia.addEventListener('change', function (e) {
+  applyTheme(e.matches);
+  view.dispatch({
+    effects: themeCompartment.reconfigure(getHighlight(e.matches)),
+  });
+});
 
 // Set initial cursor position display
 var initialPos = view.state.selection.main.head;

--- a/src/style.css
+++ b/src/style.css
@@ -148,51 +148,8 @@ body {
 /* Core editor styles are in EditorView.theme() in main.js.
        These cover markdown tokens and search highlights. */
 
-/* Markdown syntax tokens */
-.cm-header {
-  color: #d4b86a;
-  font-weight: bold;
-}
-.cm-strong {
-  color: #d4b86a;
-  font-weight: bold;
-}
-.cm-em {
-  color: #8abf8a;
-  font-style: italic;
-}
-.cm-link {
-  color: var(--accent-vis);
-}
-.cm-url {
-  color: #4e7fa0;
-  text-decoration: underline;
-}
-.cm-quote {
-  color: #7a7a68;
-  font-style: italic;
-}
-.cm-comment {
-  color: var(--fg-dim);
-}
-.cm-keyword {
-  color: #c49ad4;
-}
-.cm-atom {
-  color: #d4866a;
-}
-.cm-string {
-  color: #8abf8a;
-}
-.cm-variable-2 {
-  color: var(--accent-vis);
-}
-.cm-tag {
-  color: #c46a6a;
-}
-
 .cm-searchMatch {
-  background: #3a3a1a;
+  background: #e8d396;
 }
 
 /* ── Fold placeholder ────────────────────────────────── */

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,34 @@ html[data-theme='light'] {
   --active-line: rgba(61, 53, 48, 0.04);
 }
 
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #2a2320;
+  --bg-alt: #352b26;
+  --bg-tab: #352b26;
+  --fg: #e4d8c0;
+  --fg-dim: #a89680;
+  --fg-faint: #9f8c74;
+  --accent: #e08060;
+  --accent-soft: #d27458;
+  --accent-warm: #d4a35c;
+  --accent-vis: #8ca3b8;
+  --accent-rep: #c45a40;
+  --list-mark: #b89968;
+  --code: #9bb08a;
+  --tilde: #7a6347;
+  --rule: #4a3f37;
+  --cursor-bg: #e4d8c0;
+  --tab-active: #4a3c30;
+  --tab-border: #4a3f37;
+  --status-bg: #352b26;
+  --status-fg: #a89680;
+  --flash-fg: #b89968;
+  --sel-bg: #4a3c30;
+  --dialog-bg: #352b26;
+  --active-line: rgba(228, 216, 192, 0.04);
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -150,6 +178,10 @@ body {
 
 .cm-searchMatch {
   background: #e8d396;
+}
+
+html[data-theme='dark'] .cm-searchMatch {
+  background: #5a4a28;
 }
 
 /* ── Fold placeholder ────────────────────────────────── */

--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,9 @@ html[data-theme='light'] {
   --sel-bg: #e5d8bc;
   --dialog-bg: #ebe2d2;
   --active-line: rgba(61, 53, 48, 0.04);
+  --chrome-hover: #ddd0b8;
+  --fold-bg: #e8dcc5;
+  --fold-border: var(--rule);
 }
 
 html[data-theme='dark'] {
@@ -58,6 +61,9 @@ html[data-theme='dark'] {
   --sel-bg: #4a3c30;
   --dialog-bg: #352b26;
   --active-line: rgba(228, 216, 192, 0.04);
+  --chrome-hover: #40332c;
+  --fold-bg: #3d322c;
+  --fold-border: var(--rule);
 }
 
 * {
@@ -113,7 +119,7 @@ body {
 
 .tab:hover:not(.active) {
   color: var(--fg);
-  background: #161616;
+  background: var(--chrome-hover);
 }
 .tab.active {
   color: var(--fg);
@@ -186,8 +192,8 @@ html[data-theme='dark'] .cm-searchMatch {
 
 /* ── Fold placeholder ────────────────────────────────── */
 .cm-foldPlaceholder {
-  background: #1a1e14;
-  border: 1px solid #2a3a2a;
+  background: var(--fold-bg);
+  border: 1px solid var(--fold-border);
   color: var(--fg-dim);
   padding: 0 6px;
   border-radius: 3px;
@@ -212,7 +218,7 @@ html[data-theme='dark'] .cm-searchMatch {
   height: 22px;
   flex-shrink: 0;
   background: var(--status-bg);
-  border-top: 1px solid #1a1a1a;
+  border-top: 1px solid var(--rule);
   display: flex;
   align-items: center;
   padding: 0 10px;

--- a/src/style.css
+++ b/src/style.css
@@ -1,21 +1,35 @@
 :root {
-  --bg: #0c0c0c;
-  --bg-alt: #151515;
-  --bg-tab: #0f0f0f;
-  --fg: #b8b8a8;
-  --fg-dim: #555548;
-  --accent: #6aab73;
-  --accent-warm: #c9964a;
-  --accent-vis: #6a9fc4;
-  --accent-rep: #c46a6a;
-  --cursor-bg: #b8b8a8;
-  --tab-active: #1a261a;
-  --tab-border: #2a2a2a;
-  --status-bg: #0a0a0a;
-  --status-fg: #666;
-  --flash-fg: #8abf8a;
-  --sel-bg: #1e3320;
-  --dialog-bg: #111;
+  /* Palette defaults to light; html[data-theme] selectors refine.
+     See docs/plans/2026-04-19-theme-design.md §3 for the full spec. */
+  color-scheme: light;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --bg: #f4ede0;
+  --bg-alt: #ebe2d2;
+  --bg-tab: #ebe2d2;
+  --fg: #3d3530;
+  --fg-dim: #6b5d4f;
+  --fg-faint: #987b5a;
+  --accent: #c4634d;
+  --accent-soft: #b05d2b;
+  --accent-warm: #b88a3c;
+  --accent-vis: #6b8094;
+  --accent-rep: #9a3a2a;
+  --list-mark: #9a7540;
+  --code: #7a8f6e;
+  --tilde: #b89968;
+  --rule: #c9b898;
+  --cursor-bg: #3d3530;
+  --tab-active: #e5d8bc;
+  --tab-border: #d4c8ae;
+  --status-bg: #ebe2d2;
+  --status-fg: #6b5d4f;
+  --flash-fg: #9a7540;
+  --sel-bg: #e5d8bc;
+  --dialog-bg: #ebe2d2;
+  --active-line: rgba(61, 53, 48, 0.04);
 }
 
 * {

--- a/src/style.css
+++ b/src/style.css
@@ -103,7 +103,7 @@ body {
 #preview-container {
   flex: 1;
   overflow-y: auto;
-  background: #f5f3ee;
+  background: var(--bg);
   display: none;
 }
 
@@ -120,9 +120,9 @@ body {
   top: 52px;
   right: 20px;
   z-index: 10;
-  background: #e8e5de;
-  color: #333;
-  border: 1px solid #c4b89a;
+  background: var(--bg-alt);
+  color: var(--fg);
+  border: 1px solid var(--rule);
   border-radius: 4px;
   padding: 6px 16px;
   font-size: 14px;
@@ -131,16 +131,16 @@ body {
   transition: background 0.15s;
 }
 #preview-copy:hover {
-  background: #d8d4cc;
+  background: var(--tab-active);
 }
 #preview-copy:active {
-  background: #c8c4bc;
+  background: var(--tab-border);
 }
 
 #help-container {
   flex: 1;
   overflow-y: auto;
-  background: #f5f3ee;
+  background: var(--bg);
   display: none;
 }
 
@@ -238,32 +238,32 @@ body {
   font-family: Georgia, 'Times New Roman', 'Noto Serif', serif;
   font-size: 19px;
   line-height: 1.75;
-  color: #2a2a2a;
+  color: var(--fg);
 }
 
 #preview-content h1 {
   font-size: 2em;
   margin: 0.8em 0 0.4em;
   font-weight: 700;
-  color: #111;
+  color: var(--fg);
 }
 #preview-content h2 {
   font-size: 1.5em;
   margin: 1em 0 0.3em;
   font-weight: 600;
-  color: #1a1a1a;
+  color: var(--fg);
 }
 #preview-content h3 {
   font-size: 1.2em;
   margin: 1em 0 0.3em;
   font-weight: 600;
-  color: #222;
+  color: var(--fg);
 }
 #preview-content h4 {
   font-size: 1em;
   margin: 1em 0 0.2em;
   font-weight: 600;
-  color: #333;
+  color: var(--fg);
 }
 
 #preview-content p {
@@ -271,7 +271,7 @@ body {
 }
 
 #preview-content a {
-  color: #2a5a8a;
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -285,25 +285,26 @@ body {
 }
 
 #preview-content blockquote {
-  border-left: 3px solid #c4b89a;
+  border-left: 3px solid var(--rule);
   margin: 1em 0;
   padding: 0.3em 0 0.3em 1.2em;
-  color: #555;
+  color: var(--fg-faint);
   font-style: italic;
 }
 
 #preview-content code {
   font-family:
     ui-monospace, 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace;
-  background: #eae7e0;
+  background: var(--bg-alt);
   padding: 2px 5px;
   border-radius: 3px;
   font-size: 0.88em;
 }
 
 #preview-content pre {
-  background: #1a1a1a;
-  color: #b8b8a8;
+  background: var(--bg-alt);
+  color: var(--fg);
+  border: 1px solid var(--rule);
   padding: 16px 20px;
   border-radius: 5px;
   overflow-x: auto;
@@ -325,31 +326,31 @@ body {
 }
 #preview-content th,
 #preview-content td {
-  border: 1px solid #d0cdc6;
+  border: 1px solid var(--rule);
   padding: 8px 12px;
   text-align: left;
 }
 #preview-content th {
-  background: #eae7e0;
+  background: var(--bg-alt);
   font-weight: 600;
 }
 #preview-content tr:nth-child(even) td {
-  background: #f9f7f3;
+  background: var(--bg-alt);
 }
 
 #preview-content hr {
   border: none;
-  border-top: 1px solid #d0cdc6;
+  border-top: 1px solid var(--rule);
   margin: 2em 0;
 }
 
 #preview-content del {
-  color: #999;
+  color: var(--fg-dim);
 }
 
 #preview-content input[type='checkbox'] {
   margin-right: 6px;
-  accent-color: #6aab73;
+  accent-color: var(--accent);
 }
 
 #preview-content img {
@@ -368,8 +369,8 @@ body {
   overflow-y: auto;
   display: none;
   z-index: 5;
-  background: #eceae4;
-  border-right: 1px solid #d8d5ce;
+  background: var(--bg-alt);
+  border-right: 1px solid var(--rule);
 }
 
 #help-toc-header {
@@ -378,9 +379,9 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: #999;
+  color: var(--fg-dim);
   padding: 0 8px 8px;
-  border-bottom: 1px solid #d8d5ce;
+  border-bottom: 1px solid var(--rule);
   margin-bottom: 8px;
 }
 
@@ -400,7 +401,7 @@ body {
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 11px;
   line-height: 1.5;
-  color: #666;
+  color: var(--fg-dim);
   text-decoration: none;
   border-left: 2px solid transparent;
   transition:
@@ -409,12 +410,12 @@ body {
 }
 
 #help-toc a:hover {
-  color: #2a2a2a;
+  color: var(--fg);
 }
 
 #help-toc a.active {
-  color: #1a1a1a;
-  border-left-color: #8a7a5a;
+  color: var(--fg);
+  border-left-color: var(--list-mark);
   font-weight: 600;
 }
 
@@ -425,20 +426,20 @@ body {
   top: 42px;
   left: 8px;
   z-index: 7;
-  background: #e2dfd8;
-  border: 1px solid #d0cdc5;
+  background: var(--bg-alt);
+  border: 1px solid var(--rule);
   border-radius: 3px;
   padding: 3px 10px;
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 11px;
-  color: #666;
+  color: var(--fg-dim);
   cursor: pointer;
   line-height: 1.5;
 }
 
 #help-toc-toggle:hover {
-  color: #2a2a2a;
-  border-color: #b8b5ae;
+  color: var(--fg);
+  border-color: var(--tab-border);
 }
 
 /* Shift help content right when TOC is visible (wide screens) */
@@ -473,18 +474,18 @@ body {
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
   font-size: 18px;
   line-height: 1.6;
-  color: #2a2a2a;
+  color: var(--fg);
 }
 
 #help-content h1 {
   font-size: 1.8em;
   margin: 0 0 0.1em;
   font-weight: 700;
-  color: #111;
+  color: var(--fg);
 }
 
 #help-content .subtitle {
-  color: #777;
+  color: var(--fg-dim);
   margin: 0 0 2em;
   font-size: 1em;
 }
@@ -493,8 +494,8 @@ body {
   font-size: 1.15em;
   margin: 2em 0 0.5em;
   font-weight: 600;
-  color: #1a1a1a;
-  border-bottom: 1px solid #ddd;
+  color: var(--fg);
+  border-bottom: 1px solid var(--rule);
   padding-bottom: 0.3em;
 }
 
@@ -511,7 +512,7 @@ body {
 }
 
 #help-content a {
-  color: #2a5a8a;
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -524,22 +525,22 @@ body {
 
 #help-content th,
 #help-content td {
-  border: 1px solid #d8d5ce;
+  border: 1px solid var(--rule);
   padding: 6px 10px;
   text-align: left;
 }
 
 #help-content th {
-  background: #eae7e0;
+  background: var(--bg-alt);
   font-weight: 600;
   font-size: 0.9em;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: #555;
+  color: var(--fg-dim);
 }
 
 #help-content tr:nth-child(even) td {
-  background: #f9f7f3;
+  background: var(--bg-alt);
 }
 
 #help-content kbd {
@@ -547,17 +548,17 @@ body {
   padding: 1px 6px;
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 0.88em;
-  color: #333;
-  background: #f0ede6;
-  border: 1px solid #ccc;
+  color: var(--fg);
+  background: var(--bg-alt);
+  border: 1px solid var(--rule);
   border-radius: 3px;
-  box-shadow: 0 1px 0 #bbb;
+  box-shadow: 0 1px 0 var(--tab-border);
   line-height: 1.4;
 }
 
 #help-content code {
   font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  background: #eae7e0;
+  background: var(--bg-alt);
   padding: 2px 5px;
   border-radius: 3px;
   font-size: 0.88em;
@@ -565,31 +566,32 @@ body {
 
 #help-content hr {
   border: none;
-  border-top: 2px solid #d0cdc6;
+  border-top: 2px solid var(--rule);
   margin: 2.5em 0;
 }
 
 #help-content .tip {
   margin: 1em 0;
   padding: 10px 14px;
-  border-left: 3px solid #c4b89a;
-  background: #f9f7f3;
+  border-left: 3px solid var(--rule);
+  background: var(--bg-alt);
   font-size: 0.92em;
-  color: #444;
+  color: var(--fg-dim);
   line-height: 1.55;
 }
 
 #help-content .tip b {
-  color: #333;
+  color: var(--fg);
 }
 
 #help-content .tip code {
-  background: #eae7e0;
+  background: var(--bg-alt);
 }
 
 #help-content pre {
-  background: #1a1a1a;
-  color: #b8b8a8;
+  background: var(--bg-alt);
+  color: var(--fg);
+  border: 1px solid var(--rule);
   padding: 14px 18px;
   border-radius: 5px;
   overflow-x: auto;

--- a/src/template.html
+++ b/src/template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/template.html
+++ b/src/template.html
@@ -1016,6 +1016,11 @@
             for a markdown editor. <code>spell</code> uses the browser&rsquo;s
             built-in spellcheck rather than vim&rsquo;s spell engine.
           </div>
+          <div class="tip">
+            <b>Appearance:</b> vi.html follows your operating system&rsquo;s
+            light/dark mode preference automatically. Change your OS appearance
+            and the editor recolors immediately &mdash; no reload, no setting.
+          </div>
 
           <h2 id="s-keyboard-shortcuts">vi.html Keyboard Shortcuts</h2>
           <table>

--- a/src/template.html
+++ b/src/template.html
@@ -1141,7 +1141,7 @@ persist</pre
           <h2 id="s-end-of-buffer">End-of-Buffer Lines</h2>
           <p>
             Lines below the end of the document are marked with
-            <code style="color: #4e5a8a">~</code>, matching vim&rsquo;s
+            <code style="color: var(--tilde)">~</code>, matching vim&rsquo;s
             end-of-buffer indicator. These are not part of the document &mdash;
             they show where the file ends and empty screen space begins.
           </p>

--- a/src/vim/highlight.js
+++ b/src/vim/highlight.js
@@ -29,9 +29,24 @@ export const lightHighlight = HighlightStyle.define([
 ]);
 
 /**
- * Espresso Mirror (dark) highlight. Filled in Slice 4.
+ * Espresso Mirror (dark) highlight.
  */
-export const darkHighlight = null; // populated in Slice 4
+export const darkHighlight = HighlightStyle.define([
+  { tag: t.heading1, color: '#e08060', fontWeight: 'bold' },
+  { tag: t.heading2, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading3, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading4, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading5, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.heading6, color: '#d27458', fontWeight: 'bold' },
+  { tag: t.emphasis, color: '#e08060', fontStyle: 'italic' },
+  { tag: t.strong, color: '#e08060', fontWeight: 'bold' },
+  { tag: t.link, color: '#e08060' },
+  { tag: t.url, color: '#e08060' },
+  { tag: t.monospace, color: '#9bb08a' },
+  { tag: t.quote, color: '#9f8c74', fontStyle: 'italic' },
+  { tag: t.processingInstruction, color: '#b89968' },
+  { tag: t.contentSeparator, color: '#4a3f37' },
+]);
 
 /**
  * Returns a syntax-highlighting extension for the requested variant.

--- a/src/vim/highlight.js
+++ b/src/vim/highlight.js
@@ -1,0 +1,42 @@
+/**
+ * Markdown syntax highlighting for Paper & Clay (light) and Espresso Mirror (dark).
+ *
+ * HighlightStyle inlines its styles at creation time, so CSS variables cannot
+ * reach into the generated CSS. Hex values are hardcoded per
+ * docs/plans/2026-04-19-theme-design.md §3; keep both tables in sync.
+ */
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+/**
+ * Paper & Clay (light) highlight.
+ */
+export const lightHighlight = HighlightStyle.define([
+  { tag: t.heading1, color: '#c4634d', fontWeight: 'bold' },
+  { tag: t.heading2, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading3, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading4, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading5, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.heading6, color: '#b05d2b', fontWeight: 'bold' },
+  { tag: t.emphasis, color: '#c4634d', fontStyle: 'italic' },
+  { tag: t.strong, color: '#c4634d', fontWeight: 'bold' },
+  { tag: t.link, color: '#c4634d' },
+  { tag: t.url, color: '#c4634d' },
+  { tag: t.monospace, color: '#7a8f6e' },
+  { tag: t.quote, color: '#987b5a', fontStyle: 'italic' },
+  { tag: t.processingInstruction, color: '#9a7540' },
+  { tag: t.contentSeparator, color: '#c9b898' },
+]);
+
+/**
+ * Espresso Mirror (dark) highlight. Filled in Slice 4.
+ */
+export const darkHighlight = null; // populated in Slice 4
+
+/**
+ * Returns a syntax-highlighting extension for the requested variant.
+ * `isDark` true → dark, false → light.
+ */
+export function getHighlight(isDark) {
+  return syntaxHighlighting(isDark ? darkHighlight : lightHighlight);
+}

--- a/src/vim/highlight.test.js
+++ b/src/vim/highlight.test.js
@@ -4,7 +4,7 @@
  */
 import { describe, test, expect } from 'vitest';
 import { tags as t } from '@lezer/highlight';
-import { lightHighlight } from './highlight.js';
+import { lightHighlight, darkHighlight } from './highlight.js';
 
 describe('lightHighlight (Paper & Clay)', () => {
   test('constructs without error', () => {
@@ -78,5 +78,72 @@ describe('lightHighlight (Paper & Clay)', () => {
 
   test('contentSeparator is rule', () => {
     expect(specFor(t.contentSeparator).color).toBe('#c9b898');
+  });
+});
+
+describe('darkHighlight (Espresso Mirror)', () => {
+  test('constructs without error', () => {
+    expect(darkHighlight).toBeTruthy();
+  });
+
+  const specs = darkHighlight.specs;
+  function specFor(tag) {
+    return specs.find((s) => {
+      const tags = Array.isArray(s.tag) ? s.tag : [s.tag];
+      return tags.includes(tag);
+    });
+  }
+
+  test('heading1 is dark accent, bold', () => {
+    const s = specFor(t.heading1);
+    expect(s.color).toBe('#e08060');
+    expect(s.fontWeight).toBe('bold');
+  });
+
+  test('heading2–heading6 are accent-soft, bold', () => {
+    for (const tag of [
+      t.heading2,
+      t.heading3,
+      t.heading4,
+      t.heading5,
+      t.heading6,
+    ]) {
+      expect(specFor(tag).color).toBe('#d27458');
+      expect(specFor(tag).fontWeight).toBe('bold');
+    }
+  });
+
+  test('emphasis is italic accent', () => {
+    const s = specFor(t.emphasis);
+    expect(s.color).toBe('#e08060');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('strong is bold accent', () => {
+    expect(specFor(t.strong).color).toBe('#e08060');
+    expect(specFor(t.strong).fontWeight).toBe('bold');
+  });
+
+  test('link and url are accent', () => {
+    expect(specFor(t.link).color).toBe('#e08060');
+    expect(specFor(t.url).color).toBe('#e08060');
+  });
+
+  test('monospace is dark sage', () => {
+    expect(specFor(t.monospace).color).toBe('#9bb08a');
+  });
+
+  test('quote is fg-faint, italic', () => {
+    const s = specFor(t.quote);
+    expect(s.color).toBe('#9f8c74');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('processingInstruction is list-mark', () => {
+    expect(specFor(t.processingInstruction).color).toBe('#b89968');
+  });
+
+  test('contentSeparator is rule', () => {
+    expect(specFor(t.contentSeparator).color).toBe('#4a3f37');
   });
 });

--- a/src/vim/highlight.test.js
+++ b/src/vim/highlight.test.js
@@ -31,7 +31,13 @@ describe('lightHighlight (Paper & Clay)', () => {
   });
 
   test('heading2–heading6 are accent-soft, bold', () => {
-    for (const tag of [t.heading2, t.heading3, t.heading4, t.heading5, t.heading6]) {
+    for (const tag of [
+      t.heading2,
+      t.heading3,
+      t.heading4,
+      t.heading5,
+      t.heading6,
+    ]) {
       const s = specFor(tag);
       expect(s).toBeDefined();
       expect(s.color).toBe('#b05d2b');

--- a/src/vim/highlight.test.js
+++ b/src/vim/highlight.test.js
@@ -1,0 +1,76 @@
+/**
+ * Markdown syntax highlighting — palette spec regression guard.
+ * See docs/plans/2026-04-19-theme-design.md §3 for the palette spec.
+ */
+import { describe, test, expect } from 'vitest';
+import { tags as t } from '@lezer/highlight';
+import { lightHighlight } from './highlight.js';
+
+describe('lightHighlight (Paper & Clay)', () => {
+  test('constructs without error', () => {
+    expect(lightHighlight).toBeTruthy();
+  });
+
+  // A HighlightStyle exposes its raw spec via the `specs` property.
+  // If that API ever changes, these tests will break loudly — which is
+  // the point of a regression guard.
+  const specs = lightHighlight.specs;
+
+  function specFor(tag) {
+    return specs.find((s) => {
+      const tags = Array.isArray(s.tag) ? s.tag : [s.tag];
+      return tags.includes(tag);
+    });
+  }
+
+  test('heading1 is clay red, bold', () => {
+    const s = specFor(t.heading1);
+    expect(s).toBeDefined();
+    expect(s.color).toBe('#c4634d');
+    expect(s.fontWeight).toBe('bold');
+  });
+
+  test('heading2–heading6 are accent-soft, bold', () => {
+    for (const tag of [t.heading2, t.heading3, t.heading4, t.heading5, t.heading6]) {
+      const s = specFor(tag);
+      expect(s).toBeDefined();
+      expect(s.color).toBe('#b05d2b');
+      expect(s.fontWeight).toBe('bold');
+    }
+  });
+
+  test('emphasis is italic accent', () => {
+    const s = specFor(t.emphasis);
+    expect(s.color).toBe('#c4634d');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('strong is bold accent', () => {
+    const s = specFor(t.strong);
+    expect(s.color).toBe('#c4634d');
+    expect(s.fontWeight).toBe('bold');
+  });
+
+  test('link and url are accent', () => {
+    expect(specFor(t.link).color).toBe('#c4634d');
+    expect(specFor(t.url).color).toBe('#c4634d');
+  });
+
+  test('monospace is sage', () => {
+    expect(specFor(t.monospace).color).toBe('#7a8f6e');
+  });
+
+  test('quote is fg-faint, italic', () => {
+    const s = specFor(t.quote);
+    expect(s.color).toBe('#987b5a');
+    expect(s.fontStyle).toBe('italic');
+  });
+
+  test('processingInstruction is list-mark', () => {
+    expect(specFor(t.processingInstruction).color).toBe('#9a7540');
+  });
+
+  test('contentSeparator is rule', () => {
+    expect(specFor(t.contentSeparator).color).toBe('#c9b898');
+  });
+});

--- a/src/vim/index.js
+++ b/src/vim/index.js
@@ -26,3 +26,4 @@ export {
   registerFoldCommands,
 } from './fold.js';
 export { registerClipboard } from './clipboard.js';
+export { lightHighlight, darkHighlight, getHighlight } from './highlight.js';


### PR DESCRIPTION
## Summary

Implements Sprint 2 roadmap item #3: the "Her" treatment theme.

- **Light (Paper & Clay)** — warm parchment + espresso + clay-red accent.
- **Dark (Espresso Mirror)** — same family, lamp-lit.
- **OS-follow** via `prefers-color-scheme`; no manual override, no persistence (OS is the source of truth).
- Ships the **markdown syntax highlighting** that was silently missing from the editor (the CM5-era token CSS at `src/style.css:138–178` was dead rules CM6 never emits — deleted).

Design doc: `docs/plans/2026-04-19-theme-design.md`
Implementation plan: `docs/plans/2026-04-19-theme.md`

## Test plan

- [x] `npm run check` green
- [x] `npm run build` green
- [x] Unit tests cover both `HighlightStyle` variants (hex regression guard)
- [ ] Light-mode screenshots attached (editor, preview, help) — to be attached via web UI
- [ ] Dark-mode screenshots attached (editor, preview, help) — to be attached via web UI
- [x] Live OS-theme flip exercises the `matchMedia` change path; no reload, no cursor jump (verified via Playwright `emulateMedia`; dark heading1 computed color resolves to `rgb(224, 128, 96)` = `#e08060` as expected)

Screenshots live at `~/screenshots/theme-{light,dark}-{editor,preview,help}.png` locally and will be attached via the PR web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)