### PR TITLE
Systematic audit of src/vim/ against upstream

### DIFF
--- a/docs/plans/2026-04-19-vim-audit-design.md
+++ b/docs/plans/2026-04-19-vim-audit-design.md
@@ -1,0 +1,106 @@
+# Systematic audit of `src/vim/` against upstream — design
+
+**Issue:** [#26](https://github.com/chris-biagini/vi.html/issues/26)
+**Branch:** `feature/vim-audit-26`
+**Status:** design — awaiting user review before writing the implementation plan
+
+## Context
+
+Prior audits of custom vim code against upstream have been reactive — triggered by specific feature plans. Each one found something:
+
+- **List continuation (#12):** built a custom handler, then discovered CM6 + `@codemirror/lang-markdown` already did it natively. Reverted the feature, kept the docs. This audit was the source of the `cm6_native_coverage` memory and the "verify native CM6 behavior *before* planning" rule in `CLAUDE.md`.
+- **Macros + `:g`/`:v` (#19, #20):** both fully supported upstream. Closed as docs-only.
+- **Spellcheck:** `:set spell` replaced with the browser `spellcheck` attribute.
+
+The hit rate — three-for-three — suggests there is real, unreviewed code in `src/vim/` that upstream now covers. This spec describes a systematic, file-by-file pass.
+
+## Goal
+
+Every file in `src/vim/` gets a verdict — **keep**, **slim**, or **delete** — with a one-sentence justification citing either an upstream line reference or a harness test. Deletions and slimming land as separate follow-up PRs in future sessions. This session ships only the audit report and the follow-up issues.
+
+## Scope
+
+All 13 files in `src/vim/`:
+
+| File | LoC | Tier |
+|---|---:|---|
+| `gq.js` | 144 | priority suspect |
+| `options.js` | 79 | priority suspect |
+| `textwidth.js` | 50 | priority suspect |
+| `fold.js` | 73 | priority suspect |
+| `clipboard.js` | 23 | priority suspect |
+| `arrow-clamp.js` | 29 | priority suspect |
+| `highlight.js` | 57 | priority suspect |
+| `abbreviations.js` | 127 | quick-skim |
+| `buffers.js` | 184 | quick-skim |
+| `commands.js` | 108 | quick-skim |
+| `exrc.js` | 92 | quick-skim |
+| `mappings.js` | 12 | quick-skim |
+| `tilde.js` | 101 | quick-skim |
+
+(LoC from issue #26 where cited; approximate otherwise — the subagents will use real line counts.)
+
+## Method
+
+Per `CLAUDE.md` "verify native CM6 behavior *before* planning":
+
+1. **Grep the upstream bundle:** `node_modules/@replit/codemirror-vim/dist/index.js` (~8,774 lines). Look for operator names, option names, registers, or other identifiers relevant to the file under audit.
+2. **Check CM6 packages:** `@codemirror/view`, `@codemirror/state`, `@codemirror/language`, `@codemirror/lang-markdown`.
+3. **Empirical verification via `?test` harness** when the hypothesis is ambiguous: strip (or bypass) the custom handler and drive the target scenario through `window.__vi`; observe whether upstream behavior alone covers the need. Harness usage notes are in `CLAUDE.md` → "Browser Testing (Playwright)".
+
+## Execution — parallel Opus subagents
+
+Seven subagents, dispatched in parallel. Each gets: the file(s) to audit, the stated hypothesis, path to the upstream bundle, harness quirks from `CLAUDE.md`, and a required output shape (verdict + justification + citations + proposed next step).
+
+| # | File(s) | Hypothesis to test |
+|---|---|---|
+| 1 | `gq.js` | Upstream exposes a `hardWrap` operator or paragraph-reflow primitive that could replace our gq/gw handler. |
+| 2 | `options.js` + `textwidth.js` (paired) | Upstream already plumbs `number`, `relativenumber`, `textwidth`; for `textwidth`, upstream may also wrap on insert, making our handler redundant. Paired because findings in one reframe the other. |
+| 3 | `clipboard.js` | `@replit/codemirror-vim` now routes `"*` to the OS clipboard without our shim. |
+| 4 | `fold.js` | `@codemirror/language` + `@codemirror/lang-markdown` already detect heading fold ranges; our custom folding may duplicate them. |
+| 5 | `arrow-clamp.js` | A CM6 option or extension stops arrow keys from wrapping lines in insert mode. |
+| 6 | `highlight.js` | The tweaks duplicate what `@codemirror/lang-markdown` default styles already cover. |
+| 7 | Quick-skim batch: `abbreviations.js`, `buffers.js`, `commands.js`, `exrc.js`, `mappings.js`, `tilde.js` | Confirm these address browser/app concerns upstream has no reason to handle; flag any surprises for deeper review. |
+
+## Deliverable
+
+A single committed document, `docs/plans/2026-04-19-vim-audit.md`, containing:
+
+1. **Context** — link to #26, why we audited, date.
+2. **Method** — recap of the grep-plus-harness approach.
+3. **Verdict table** — one row per file:
+   - file path, LoC, hypothesis tested
+   - verdict: **keep** / **slim** / **delete**
+   - justification: one sentence citing either a bundle line reference or a harness scenario
+   - follow-up: issue # / PR # / N/A
+4. **Summary of follow-ups filed** — the issue numbers this audit spun off.
+5. **Memory updates** — a list of edits to apply to `~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md`. The memory file itself is updated directly (it lives outside the repo); the list in the report records what changed and why.
+
+## Follow-up policy
+
+- **Delete** verdict → open a GitHub issue with the subagent's findings attached. Do not open a PR in this session.
+- **Slim** verdict → same.
+- **Keep** verdict → no follow-up needed. Justification in the audit table is the record.
+
+Closing #26 when the audit report is merged is the done-criteria gate — every file has a verdict; every delete/slim verdict has a follow-up issue.
+
+## Out of scope
+
+- Actually deleting or slimming code. Each of those is its own branch, its own PR, its own session.
+- Non-vim files (`main.js`, `preview.js`, etc.). Issue #26 is explicit about this.
+- Modernization-for-its-own-sake. Only delete or slim where upstream genuinely covers the need.
+
+## Risks and mitigations
+
+- **Risk:** a subagent returns an over-confident "delete" verdict based on a grep match that isn't really the same behavior. **Mitigation:** require the subagent's justification to either cite the upstream *implementation* (not just a symbol match) or cite a harness scenario proving the behavior. The reviewer (and me, when aggregating) can sanity-check the citation.
+- **Risk:** a paired audit (options + textwidth) produces findings that conflict. **Mitigation:** the paired subagent owns both files and must reconcile in its own report; the main session doesn't need to.
+- **Risk:** the audit misses a file because of a grouping error. **Mitigation:** the verdict table in the report must list *all* 13 files; if any row is missing, the audit isn't done.
+
+## References
+
+- Issue: https://github.com/chris-biagini/vi.html/issues/26
+- List-continuation audit (the exemplar): commit `9bee602`, `docs/plans/2026-04-19-list-continuation.md`
+- Upstream bundle: `node_modules/@replit/codemirror-vim/dist/index.js`
+- Memory: `~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md`
+- `CLAUDE.md` → "Architectural Commitments" → "Verify native CM6 behavior *before* planning."
+- `CLAUDE.md` → "Browser Testing (Playwright)" for `?test` harness usage.

--- a/docs/plans/2026-04-19-vim-audit-plan.md
+++ b/docs/plans/2026-04-19-vim-audit-plan.md
@@ -1,0 +1,409 @@
+# Vim Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a single audit report covering all 13 files in `src/vim/` with keep/slim/delete verdicts, file follow-up GH issues for each delete/slim verdict, and close #26. No code is deleted or modified in this session.
+
+**Architecture:** Seven parallel Opus subagents perform independent file-by-file audits. Their findings are aggregated into one committed audit report (`docs/plans/2026-04-19-vim-audit.md`). Each delete/slim verdict spawns a follow-up GH issue. The PR is merge-closes #26.
+
+**Tech Stack:** `@replit/codemirror-vim` (bundled at `node_modules/@replit/codemirror-vim/dist/index.js`, ~8,774 lines) + CodeMirror 6 packages (`@codemirror/view`, `@codemirror/state`, `@codemirror/language`, `@codemirror/lang-markdown`). Empirical verification via the `?test` harness documented in `CLAUDE.md`.
+
+**Spec:** `docs/plans/2026-04-19-vim-audit-design.md` (committed on this branch at `ceaabe9`).
+
+**Branch:** `feature/vim-audit-26` (already created).
+
+---
+
+## File Structure
+
+No source files are created, modified, or deleted in this session. The audit is strictly diagnostic. Artifacts this plan produces:
+
+- **Create:** `docs/plans/2026-04-19-vim-audit.md` — the audit report (committed, reviewed, merged with the PR).
+- **Modify:** `~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md` — new native-behavior confirmations (not committed; lives outside the repo).
+- **Create:** one GH issue per delete/slim verdict (zero or more, depending on findings).
+- **Create:** one GH PR that merge-closes #26 via `Resolves #26`.
+
+No changes to `src/`, `package.json`, `build.js`, or tests. If a subagent proposes removing code, that proposal becomes an issue, not a change in this PR.
+
+---
+
+## Task 1: Pre-flight — capture file inventory and confirm bundle location
+
+**Files:**
+- Read-only: `src/vim/*.js`, `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: List `src/vim/` with line counts**
+
+Run:
+
+```bash
+wc -l src/vim/*.js | sort -n
+```
+
+Expected: 13 `.js` files (excluding `*.test.js`), ranging from ~12 lines (`mappings.js`) to ~184 lines (`buffers.js`).
+
+- [ ] **Step 2: Verify the upstream bundle exists and confirm its size**
+
+Run:
+
+```bash
+wc -l node_modules/@replit/codemirror-vim/dist/index.js
+```
+
+Expected: ~8,774 lines. If the file is missing, run `npm install` before proceeding — the audit depends on grepping this bundle.
+
+- [ ] **Step 3: Record the file inventory for use in subagent briefs**
+
+Paste the `wc -l` output from Step 1 into a scratch note (kept in this task's TaskOutput) so subsequent audit subagents can reference accurate LoC figures. No file is written here — the output is referenced by later tasks via the task list.
+
+- [ ] **Step 4: No commit** — this task is a read-only inventory.
+
+---
+
+## Tasks 2–8: Parallel audit subagents
+
+> **Dispatch policy:** Tasks 2 through 8 are independent and MUST be dispatched in parallel as Opus subagents (per `~/.interslice-common/subagents.md`). They do not modify any files — each returns a verdict plus evidence in its task output. Do not wait for one to finish before dispatching the next.
+
+Each subagent receives the same **brief template** below, with the `{{FILE}}`, `{{HYPOTHESIS}}`, and any paired-file notes filled in per task.
+
+### Subagent brief template
+
+> You are performing a narrow, one-file (or paired-file) audit of the vi.html project's custom vim code against the upstream `@replit/codemirror-vim` bundle and CodeMirror 6 packages.
+>
+> **The repo root is `/home/claude/vi.html`. Work only within that directory.** Do not modify any files in `src/`, `node_modules/`, `docs/`, `tests/`, or elsewhere — this is a read-only audit. Do not run `npm install`, `git commit`, `git push`, or any destructive command.
+>
+> **File(s) under audit:** `{{FILE}}`
+>
+> **Hypothesis to test:** {{HYPOTHESIS}}
+>
+> **Method (in this order):**
+>
+> 1. **Read the target file(s).** Know what each function does and what it touches.
+> 2. **Grep the upstream bundle** at `node_modules/@replit/codemirror-vim/dist/index.js` (~8,774 lines) for identifiers relevant to the hypothesis — operator names, option names, registers, `defineOption` calls, `defineOperator` calls, etc. When you find matches, **read the surrounding implementation** — a symbol match isn't a behavior match.
+> 3. **Check CM6 packages** in `node_modules/@codemirror/`: `view`, `state`, `language`, `lang-markdown`. Focus on extension/option declarations and markdown-specific helpers relevant to the hypothesis.
+> 4. **Only if grep evidence is ambiguous:** run an empirical check via the `?test` harness. Usage notes are in `/home/claude/vi.html/CLAUDE.md` under "Browser Testing (Playwright)". You may `npm run build` and serve locally with `python3 -m http.server 9876 --bind 0.0.0.0`, then navigate Playwright to `http://rika:9876/vi.html?test`. **Do not modify any file to run this test** — if you need to bypass a custom handler to verify upstream alone, describe what you would change rather than actually changing it, unless you can do so in a way that reverts cleanly before returning.
+>
+> **Required output shape.** Return exactly this structure:
+>
+> ```markdown
+> ## Audit: `{{FILE}}`
+>
+> **LoC (non-test):** [number]
+> **Hypothesis tested:** {{HYPOTHESIS}}
+>
+> **Verdict:** [keep | slim | delete]
+>
+> **Justification** (≤3 sentences):
+> [Cite specific bundle line numbers (e.g., "see `defineOption('textwidth', ...)` at bundle line 4521") OR cite a harness scenario transcript. A symbol match alone is not acceptable — you must have read the upstream implementation or verified behavior empirically.]
+>
+> **Evidence:**
+> - [bundle line refs or harness transcript]
+> - [CM6 package refs if relevant]
+>
+> **Proposed next step:**
+> [If keep: "No follow-up. Justification above is the record."
+>  If slim: "Open issue: '<short title>'. Scope: <concrete what-to-remove-or-simplify>, leaving <what-stays> because <reason>."
+>  If delete: "Open issue: '<short title>'. Scope: remove the file (and its test, if any), update `src/vim/index.js` to drop the import."]
+>
+> **Risks / caveats I couldn't resolve:**
+> [Anything the main session should double-check before filing the follow-up, or "none".]
+> ```
+>
+> **If you cannot find upstream coverage:** return `Verdict: keep` with the justification being whatever you *did* look for and not find. "Couldn't find X in the bundle" is a valid finding — don't manufacture a delete/slim verdict to feel productive.
+>
+> Keep your report under 400 words. Cite precise bundle line numbers, not paraphrases.
+
+### Task 2: Audit `gq.js`
+
+**Files:**
+- Read: `src/vim/gq.js`, `src/vim/gq.test.js` (for context on behavior), `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: Dispatch Opus subagent with the brief template**, filling in:
+  - `{{FILE}}`: `src/vim/gq.js`
+  - `{{HYPOTHESIS}}`: "Upstream `@replit/codemirror-vim` exposes a `hardWrap` operator or paragraph-reflow primitive that could replace our custom gq/gw handler. The codemirror-vim README shows a `hardWrap` extension hook — check whether the bundle now ships the actual operator."
+
+- [ ] **Step 2: Verify the subagent returned the required output shape.** The report must contain the `Verdict:`, `Justification:`, `Evidence:`, and `Proposed next step:` fields. If any is missing or the justification is a bare symbol match (no line numbers, no implementation reading, no harness transcript), bounce it back.
+
+- [ ] **Step 3: Save the subagent's report verbatim as the row for `gq.js`** in the eventual audit report (aggregated in Task 9). No commit at this step.
+
+### Task 3: Audit `options.js` + `textwidth.js` (paired)
+
+**Files:**
+- Read: `src/vim/options.js`, `src/vim/textwidth.js`, `src/vim/textwidth.test.js`, `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: Dispatch Opus subagent with the brief template**, filling in:
+  - `{{FILE}}`: `src/vim/options.js` AND `src/vim/textwidth.js` (paired audit — one subagent, both files)
+  - `{{HYPOTHESIS}}`: "(a) Upstream plumbs `number`, `relativenumber`, `textwidth`, `tabstop`, `shiftwidth`, `expandtab`, and similar options already — our `Vim.defineOption` calls in `options.js` may duplicate upstream-native ones. (b) For `textwidth` specifically, the upstream may also wrap on insert (not just store the value), making `textwidth.js`'s wrap handler redundant. Reconcile findings across both files — if upstream handles `textwidth` end-to-end, both files may shrink together."
+
+- [ ] **Step 2: Verify the subagent returned the required output shape for BOTH files**, either as two sections or one merged section — the subagent decides based on its findings. If one file's verdict contradicts the other's in a way that doesn't reconcile in the justification, bounce it back.
+
+- [ ] **Step 3: Save the subagent's report verbatim.** No commit.
+
+### Task 4: Audit `clipboard.js`
+
+**Files:**
+- Read: `src/vim/clipboard.js` (23 lines), `src/vim/clipboard.test.js`, `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: Dispatch Opus subagent with the brief template**, filling in:
+  - `{{FILE}}`: `src/vim/clipboard.js`
+  - `{{HYPOTHESIS}}`: "`@replit/codemirror-vim` now routes the `\"*` register to the OS clipboard without our shim. Our file was added at commit `a15cf4d`. Check whether the bundle's register-handling code aliases `*` to `+` or to the system clipboard natively now."
+
+- [ ] **Step 2: Verify the subagent's report has a bundle line number** for the register-handling code (not just a grep for `"*"`).
+
+- [ ] **Step 3: Save the subagent's report verbatim.** No commit.
+
+### Task 5: Audit `fold.js`
+
+**Files:**
+- Read: `src/vim/fold.js`, `node_modules/@codemirror/language/`, `node_modules/@codemirror/lang-markdown/`, `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: Dispatch Opus subagent with the brief template**, filling in:
+  - `{{FILE}}`: `src/vim/fold.js`
+  - `{{HYPOTHESIS}}`: "`@codemirror/language` + `@codemirror/lang-markdown` already detect heading fold ranges. Our custom heading-fold implementation may duplicate an upstream `foldInside`/`foldNodeProp` hook. Also check whether `@replit/codemirror-vim` wires `zo`/`zc`/`za`/`zR`/`zM` to CM6's fold service."
+
+- [ ] **Step 2: Verify the subagent's report distinguishes between** (a) "upstream detects fold ranges" and (b) "upstream wires vim fold commands to those ranges" — both must be true for a `delete` verdict.
+
+- [ ] **Step 3: Save the subagent's report verbatim.** No commit.
+
+### Task 6: Audit `arrow-clamp.js`
+
+**Files:**
+- Read: `src/vim/arrow-clamp.js` (29 lines), `node_modules/@codemirror/view/`, `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: Dispatch Opus subagent with the brief template**, filling in:
+  - `{{FILE}}`: `src/vim/arrow-clamp.js`
+  - `{{HYPOTHESIS}}`: "A CM6 option or extension stops arrow keys from wrapping across line boundaries in insert mode. Issue #26 flagged this as low-probability but cheap to check. Also check whether `@replit/codemirror-vim` itself clamps cursor-via-arrow during insert."
+
+- [ ] **Step 2: Verify the subagent actually checked both CM6 (view-level) and the vim bundle** — not just one or the other.
+
+- [ ] **Step 3: Save the subagent's report verbatim.** No commit.
+
+### Task 7: Audit `highlight.js`
+
+**Files:**
+- Read: `src/vim/highlight.js`, `src/vim/highlight.test.js`, `node_modules/@codemirror/lang-markdown/`, `node_modules/@codemirror/language/`
+
+- [ ] **Step 1: Dispatch Opus subagent with the brief template**, filling in:
+  - `{{FILE}}`: `src/vim/highlight.js`
+  - `{{HYPOTHESIS}}`: "`highlight.js` adds markdown syntax-highlighting tweaks. Some or all of these may duplicate what `@codemirror/lang-markdown` default styles (`markdownLanguage.extension`, `HighlightStyle` from `@codemirror/language`) already cover. A `delete` verdict requires that every token class in `highlight.js` is already styled by default upstream."
+
+- [ ] **Step 2: Verify the subagent enumerated each token rule in `highlight.js`** and matched each against upstream styles — a blanket "upstream has a highlight style" isn't enough.
+
+- [ ] **Step 3: Save the subagent's report verbatim.** No commit.
+
+### Task 8: Quick-skim batch — `abbreviations.js`, `buffers.js`, `commands.js`, `exrc.js`, `mappings.js`, `tilde.js`
+
+**Files:**
+- Read: all six target files above, plus `node_modules/@replit/codemirror-vim/dist/index.js`
+
+- [ ] **Step 1: Dispatch Opus subagent with a modified brief.** Use the template above, but override the "required output shape" to allow one short section per file (4 sentences max each). The hypothesis is:
+  - `{{FILE}}`: the six files listed above
+  - `{{HYPOTHESIS}}`: "These files are hypothesized to address browser/app concerns that `@replit/codemirror-vim` has no reason to handle: abbreviation expansion (vim abstractly defines `:ab` but implementation matters), multi-buffer management in localStorage, custom `:` Ex commands for this app (`:preview`, `:help`, `:write`), persistent exrc via localStorage, a couple of custom key mappings, and a visual-only tilde-gutter. Confirm each is genuinely our-domain — or flag any surprises (e.g., if `@replit/codemirror-vim` already implements `:ab`/`:una`/`:abc` fully, abbreviations.js might shrink)."
+
+- [ ] **Step 2: Require each of the six files to have its own one-liner verdict row** in the subagent's output. If any is missing, bounce it back.
+
+- [ ] **Step 3: Save the subagent's report verbatim.** No commit.
+
+---
+
+## Task 9: Aggregate findings into the audit report
+
+**Files:**
+- Create: `docs/plans/2026-04-19-vim-audit.md`
+
+- [ ] **Step 1: Collect the task outputs from Tasks 2–8** (seven subagent reports covering 13 files total).
+
+- [ ] **Step 2: Write the audit report** at `docs/plans/2026-04-19-vim-audit.md` with this structure:
+
+```markdown
+# Systematic audit of `src/vim/` — findings
+
+**Issue:** [#26](https://github.com/chris-biagini/vi.html/issues/26)
+**Design spec:** `docs/plans/2026-04-19-vim-audit-design.md`
+**Date:** 2026-04-19
+**Branch:** `feature/vim-audit-26`
+
+## Method
+
+[3-5 sentences recapping: 7 parallel Opus subagents, grep the upstream bundle,
+check CM6 packages, harness verification where ambiguous. Link to design spec
+for full rationale.]
+
+## Verdict table
+
+| File | LoC | Verdict | Justification (1 sentence) | Follow-up |
+|---|---:|---|---|---|
+| `gq.js` | ... | keep/slim/delete | ... | #NNN or N/A |
+| ... | ... | ... | ... | ... |
+
+(13 rows — one per file. `options.js` and `textwidth.js` are separate rows
+even though audited together. Follow-up column is filled in during Task 10.)
+
+## Per-file findings
+
+[For each file, paste the subagent's full returned report verbatim. Use
+`### ` headings. Order: priority suspects first (gq, options, textwidth,
+clipboard, fold, arrow-clamp, highlight), then quick-skim batch.]
+
+## Follow-ups filed
+
+[Populated during Task 10. Each row: issue #, title, affected file(s), verdict type.]
+
+## Memory updates
+
+[Populated during Task 11. Each row: what was added to
+~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md, why.]
+
+## Closeout
+
+Every file in `src/vim/` has a verdict. Every delete/slim verdict has a
+follow-up issue. This report ships as a PR that `Resolves #26`.
+```
+
+- [ ] **Step 3: Verify every file in `src/vim/` (excluding `*.test.js` and `index.js`) appears as a row in the verdict table.** Count: 13 source files. If any is missing, the audit isn't done.
+
+- [ ] **Step 4: No commit yet** — the report gets committed in Task 12 alongside the follow-up references. This keeps the PR's single commit readable.
+
+---
+
+## Task 10: File GitHub issues for delete/slim verdicts
+
+**Files:** None. This task creates GH issues only.
+
+- [ ] **Step 1: For each row in the verdict table with verdict `delete` or `slim`**, file a GH issue with:
+
+```bash
+gh issue create \
+  --title "<short, actionable title — e.g., 'Remove gq.js: upstream hardWrap operator covers it'>" \
+  --body "$(cat <<'EOF'
+**Verdict from [#26](https://github.com/chris-biagini/vi.html/issues/26) audit:** [delete | slim]
+
+**File(s):** `src/vim/<file>.js` (and `src/vim/<file>.test.js` if present)
+
+**Justification from audit report** (`docs/plans/2026-04-19-vim-audit.md`):
+
+> [paste the subagent's justification sentence]
+
+**Evidence:** [paste bundle line refs or harness transcript]
+
+**Proposed scope:** [paste subagent's "Proposed next step"]
+
+**Risks / caveats:** [paste from subagent report, or "none"]
+
+**Method for the follow-up PR:**
+1. Branch `feature/remove-<file>`.
+2. Delete (or slim) `src/vim/<file>.js` and its test.
+3. Remove the export from `src/vim/index.js`.
+4. Run `npm run check` and `npm run build` — must pass.
+5. Interactive browser test via `?test` harness — the behavior must still work (upstream now covers it).
+6. Open PR `Resolves #NNN`.
+EOF
+)"
+```
+
+- [ ] **Step 2: Record the returned issue number** in the "Follow-up" column of the verdict table in `docs/plans/2026-04-19-vim-audit.md` (in memory — the file hasn't been committed yet; edit in place).
+
+- [ ] **Step 3: Populate the "Follow-ups filed" section** of the audit report with one row per filed issue: `#NNN — <title> — <file> — <verdict type>`.
+
+- [ ] **Step 4: If there are zero delete/slim verdicts**, write a single sentence under "Follow-ups filed" stating so: "No delete or slim verdicts. Every file in `src/vim/` is keeping its current shape; the justifications above are the record." This is a valid audit outcome.
+
+- [ ] **Step 5: No commit** — Task 12 commits everything together.
+
+---
+
+## Task 11: Apply memory updates
+
+**Files:**
+- Modify: `~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md`
+
+- [ ] **Step 1: Read the current memory file** to know its existing shape:
+
+```bash
+cat ~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md
+```
+
+- [ ] **Step 2: For each audit that confirmed a new native-upstream behavior** (typically delete/slim verdicts, but "keep with surprising find" also qualifies), add a concise bullet to the memory file. Match the existing memory's tone and structure — do not rewrite the file.
+
+- [ ] **Step 3: In the audit report's "Memory updates" section**, record each bullet that was added, with a one-sentence reason. This is the committed trace — the memory file itself isn't part of the PR.
+
+- [ ] **Step 4: If no new native coverage was confirmed**, write "No additions. The audit either confirmed our-domain status or found gaps where upstream doesn't cover the need." under "Memory updates".
+
+- [ ] **Step 5: No commit to the repo** — the memory file lives outside the repo and is updated directly.
+
+---
+
+## Task 12: Commit the audit report, push branch, open PR
+
+**Files:**
+- Commit: `docs/plans/2026-04-19-vim-audit.md`
+
+- [ ] **Step 1: Verify the audit report is complete** — all 13 rows, all justifications filled, follow-up issue numbers populated (or the "no follow-ups" sentence), memory-updates section filled, closeout paragraph present.
+
+- [ ] **Step 2: Run the repo's pre-push check as a sanity pass** (the audit doesn't change code, so this should pass trivially — but confirms we haven't accidentally touched anything):
+
+```bash
+cd /home/claude/vi.html && npm run check
+```
+
+Expected: lint clean, tests pass (no test files were modified).
+
+- [ ] **Step 3: Stage and commit the audit report**:
+
+```bash
+cd /home/claude/vi.html && git add docs/plans/2026-04-19-vim-audit.md && git commit -m "$(cat <<'EOF'
+docs: systematic audit of src/vim/ against upstream
+
+Seven parallel subagents audited all 13 files in src/vim/ against
+@replit/codemirror-vim and CM6 packages. [N] delete verdicts,
+[M] slim verdicts, [K] keep verdicts. Follow-up issues filed per
+delete/slim verdict. No code changed in this PR.
+
+Resolves #26
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Fill in [N], [M], [K] with the actual counts from the verdict table before running.
+
+- [ ] **Step 4: Push the branch**:
+
+```bash
+cd /home/claude/vi.html && git push -u origin feature/vim-audit-26
+```
+
+- [ ] **Step 5: Open the PR**:
+
+```bash
+cd /home/claude/vi.html && gh pr create --title "Systematic audit of src/vim/ against upstream" --body "$(cat <<'EOF'
+## Summary
+- Seven parallel subagents audited all 13 files in `src/vim/` against `@replit/codemirror-vim` and CodeMirror 6 packages.
+- Verdicts: [N] delete, [M] slim, [K] keep — full table in `docs/plans/2026-04-19-vim-audit.md`.
+- [L] follow-up issues filed for delete/slim verdicts. No code changed in this PR.
+
+## Test plan
+- [ ] Verdict table has a row for every file in `src/vim/` (13 total, `*.test.js` and `index.js` excluded).
+- [ ] Each delete/slim verdict's justification cites a specific bundle line number or a harness transcript — not just a symbol match.
+- [ ] Each delete/slim verdict has a filed GH issue referenced in the "Follow-up" column.
+- [ ] `npm run check` passes on this branch (no code touched — should be trivially green).
+
+Resolves #26
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Fill in [N], [M], [K], [L] to match reality before running.
+
+- [ ] **Step 6: Report the PR URL back to the user.** Do not merge — the user merges after review. Do not close #26 manually — the `Resolves #26` in the commit body closes it when the PR merges.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every item in the design spec's "Deliverable" section is covered: context (Task 9 step 2), method recap (Task 9 step 2), verdict table (Tasks 2–9), follow-ups (Task 10), memory updates (Task 11). Every item in the design spec's "Scope" (13 files) is covered: Tasks 2–7 cover 8 files, Task 8 covers 6 files — total 14, but `options.js` + `textwidth.js` are paired in Task 3, so 13 unique files. ✓
+- **No placeholders:** every step contains the actual command, brief template, or expected content. The `[N]`, `[M]`, `[K]`, `[L]` in Task 12 are intentional fill-in markers that the executor sets from the verdict table — they are not TBD/TODO.
+- **Type consistency:** no types or methods are defined in this plan (pure research task). The only "interface" is the subagent brief output shape in Tasks 2–8, and every task references the same template.
+- **Branch state:** plan assumes execution starts on `feature/vim-audit-26` with the design spec committed at `ceaabe9`. If the branch state differs, Task 1 will surface it via `wc -l`.

--- a/docs/plans/2026-04-19-vim-audit.md
+++ b/docs/plans/2026-04-19-vim-audit.md
@@ -1,0 +1,275 @@
+# Systematic audit of `src/vim/` — findings
+
+**Issue:** [#26](https://github.com/chris-biagini/vi.html/issues/26)
+**Design spec:** `docs/plans/2026-04-19-vim-audit-design.md`
+**Implementation plan:** `docs/plans/2026-04-19-vim-audit-plan.md`
+**Date:** 2026-04-19
+**Branch:** `feature/vim-audit-26`
+
+## Method
+
+Seven Opus subagents were dispatched in parallel to audit all 13 source files in `src/vim/` against upstream `@replit/codemirror-vim` (bundled at `node_modules/@replit/codemirror-vim/dist/index.js`, 8,774 lines) and CodeMirror 6 packages (`@codemirror/view`, `@codemirror/state`, `@codemirror/language`, `@codemirror/lang-markdown`). Each subagent was given a specific hypothesis to test and a required output shape: verdict (keep / slim / delete) plus one-to-three-sentence justification citing specific upstream line numbers, not mere symbol matches. Harness verification via the `?test` flow was available if grep evidence was ambiguous, but all seven audits reached their verdicts on grep evidence alone. See the design spec for full rationale.
+
+## Verdict table
+
+| File | LoC | Verdict | Justification (1 sentence) | Follow-up |
+|---|---:|---|---|---|
+| `gq.js` | 144 | slim | Upstream `hardWrap` operator is real and keymapped to `gq`/`gw`, but its line-by-line merge + markdown-unaware reflow diverges from our paragraph-join semantics — replace our operator only after harness parity. | #27 |
+| `options.js` | 79 | slim | Upstream defines only `filetype`, `textwidth`, `langmap`, `pcre`, `insertModeEscKeysTimeout` via `defineOption`; our other 8 registrations (`number`, `relativenumber`, `tabstop`, `shiftwidth`, `expandtab`, `wrap`, `spell`, `spelllang`, `foldgutter`) do real CM6 compartment work — only the redundant `textwidth` entry can be dropped. | #28 |
+| `textwidth.js` | 50 | keep | Upstream's `textwidth` callback (bundle:545–560) only stores the value; the only upstream consumer is `hardWrap`, so insert-mode auto-wrap still lives in our file. | N/A |
+| `clipboard.js` | 23 | keep | Upstream's `validRegisters` (bundle:366) excludes `*`, and the clipboard routing at bundle:1519–1521 and 3250–3253 hardcodes `+` only — without our shim, `"*` would silently fall to the unnamed register. | N/A |
+| `fold.js` | 73 | keep | `@codemirror/lang-markdown` DOES ship a heading `foldService` at `lang-markdown/dist/index.js:43` with same-or-lesser-depth semantics, but a bundle grep for `zo`/`zc`/`za`/`zR`/`zM` returns zero matches — our `registerFoldCommands` is the only vim→CM6 fold bridge. | N/A |
+| `arrow-clamp.js` | 29 | keep | Upstream maps `<Left>`/`<Right>` to `h`/`l` without `context: 'insert'` (bundle:85–86), so arrows fall through to CM6's `moveByChar` which unconditionally crosses line boundaries (view:3637–3660); no `whichwrap` option exists in either package. | N/A |
+| `highlight.js` | 57 | keep | `@codemirror/lang-markdown` installs no `HighlightStyle` by default (grep in `lang-markdown/dist` returns zero `HighlightStyle` matches), and `main.js:148` only wires our `getHighlight()` — deletion would leave the editor visually unstyled. | N/A |
+| `abbreviations.js` | 132 | keep | Bundle grep for `abbreviat\|iabbr\|\bab\b` returns zero matches; upstream's `exCommands` table (bundle:5868–6389) never registers `ab`/`una`/`abc`. | N/A |
+| `buffers.js` | 235 | keep | CM6 is a single view with no file/buffer concept; all persistence, cursor snapshotting, `#` alternate tracking, and `:ls` rendering is app-specific with no upstream analogue. | N/A |
+| `commands.js` | 140 | keep | Only overlap is upstream's `:write` stub at bundle:6352 (trivial `CM.commands.save` call) which our buffer-aware override correctly supersedes; the other 17 Ex commands we register are app-specific. | N/A |
+| `exrc.js` | 106 | keep | Upstream has no storage layer; the `:exrc` stash/swap/restore flow is pure app orchestration. | N/A |
+| `mappings.js` | 14 | keep | Two project-specific mappings (`\p` → `:toggle`, `<C-6>` → `:b#`) that depend on app-defined Ex commands; upstream `defaultKeymap` has no equivalent. | N/A |
+| `tilde.js` | 104 | keep | Upstream `@replit/codemirror-vim` is an input/state layer only — it does no DOM rendering; the end-of-buffer `~` gutter is a pure CM6 `ViewPlugin` we own. | N/A |
+
+**Totals:** 11 keep, 2 slim, 0 delete.
+
+## Per-file findings
+
+Each subagent's report is preserved verbatim below. Priority-suspect audits first, then the quick-skim batch.
+
+### `src/vim/gq.js` (slim)
+
+**LoC (non-test):** 144
+**Hypothesis tested:** Upstream `@replit/codemirror-vim` ships a real `hardWrap` operator keymapped to `gq`/`gw`, not merely a hook.
+
+**Verdict:** slim
+
+**Justification:** Upstream already registers `gq`→`hardWrap` and `gw`→`hardWrap{keepCursor:true}` in `defaultKeymap` (index.js:189–190), defines the `hardWrap` operator at index.js:2859–2867, and provides a full paragraph-aware reflow implementation at index.js:8096–8131 that reads `textwidth` and preserves indentation. Our file's keymaps (gq.js:112, gq.js:143) and operator definitions (gq.js:85, gq.js:116) are duplicates that *override* the upstream ones. However, the upstream implementation is line-oriented (merges adjacent non-blank lines one pair at a time) rather than paragraph-first (join-then-rewrap) — our paragraph-level rejoin + `wordWrap` gives cleaner output on already-ragged input, so behavioral parity must be confirmed before deleting.
+
+**Evidence:**
+- `bundle.js:189` — `{ keys: 'gq', type: 'operator', operator: 'hardWrap' },`
+- `bundle.js:190` — `{ keys: 'gw', type: 'operator', operator: 'hardWrap', operatorArgs: {keepCursor: true}},`
+- `bundle.js:2859–2866` — `hardWrap: function(cm, operatorArgs, ranges, oldAnchor) { if (!cm.hardWrap) return; ... }` — real operator, not a stub
+- `bundle.js:7841–7843` — `hardWrap(options) { return hardWrap(this, options); }` on the CM5 compat class
+- `bundle.js:8096–8131` — full `function hardWrap(cm, options)` reading `textwidth`, merging/splitting with indentation preservation
+- `README.md:67–71` — documents `hardWrap` as a user-extensible pattern, but bundle confirms the default is also real
+
+**Proposed next step:** Open issue: "Evaluate replacing gq.js with upstream hardWrap operator". Scope: write a `?test`-harness parity suite against existing `gq.test.js` scenarios (multi-paragraph reflow, blank-line boundaries, indented paragraphs, `gw` cursor preservation); if upstream matches, delete `src/vim/gq.js` + `src/vim/gq.test.js` + the export in `src/vim/index.js` and rely on the default keymap; if it diverges on markdown constructs (lists, blockquotes, fenced code, setext headings), keep only `reflowRange`/`wordWrap` and the `defineOperator` overrides while removing the redundant `Vim.mapCommand('gq'|'gw', ...)` calls.
+
+**Risks / caveats:** Upstream's line-by-line merge strategy (bundle:8112–8127) may produce different output than our paragraph-join-then-rewrap on paragraphs with inconsistent pre-existing wrap widths; markdown constructs (lists, blockquotes, setext underlines, fenced code) are not specifically handled upstream — verify behavior on these before deleting. Cursor-landing position parity also needs browser verification.
+
+---
+
+### `src/vim/options.js` + `src/vim/textwidth.js` (paired — slim + keep)
+
+**LoC (non-test):** options.js=79, textwidth.js=50
+**Hypothesis tested:** (a) Upstream duplicates our `Vim.defineOption` registrations; (b) Upstream's `textwidth` handler also auto-wraps during insert mode.
+
+#### `src/vim/options.js`
+
+**Verdict:** slim (keep the file; drop only the redundant `textwidth` entry)
+
+**Justification:** Upstream defines only 5 options via `defineOption` — `filetype` (bundle:531), `textwidth` (bundle:545), `langmap` (bundle:1309), `pcre` (bundle:5016), and `insertModeEscKeysTimeout` (bundle:6685). It does NOT define `number`, `relativenumber`, `tabstop`, `shiftwidth`, `expandtab`, `wrap`, `spell`, `spelllang`, or `foldgutter` — a grep for quoted forms of these strings in option contexts returned zero matches. Each of our remaining option callbacks does real CM6 work (compartment reconfigs through `editorAPI`, see main.js:290–335) that upstream has no knowledge of.
+
+**Proposed next step:** Slim only the `textwidth` entry (lines 56–60): it duplicates upstream's registration at bundle:545. Our callback additionally sets `state.textwidth` and flashes — upstream's handler writes to `cm.state.textwidth` via `cm.setOption` (bundle:7767–7768) — so a tiny shim to mirror the value into `state.textwidth` (which `textwidth.js` reads) is still needed. Consider reading `Vim.getOption('textwidth', cm)` in the wrap handler instead, and dropping our `defineOption('textwidth', ...)` entirely. Keep the other eight option registrations as-is.
+
+#### `src/vim/textwidth.js`
+
+**Verdict:** keep
+
+**Justification:** Upstream's `textwidth` callback (bundle:545–560) only stores the value; it does not hook insert-mode input. The only consumer of `cm.getOption('textwidth')` upstream is `hardWrap` (bundle:8096–8129), which is invoked exclusively from the `gq` operator (bundle:2859–2867 → 2864). A grep for `insertMode.*textwidth` and `state.textwidth` confirms no insert-mode wrap path exists upstream. Without our handler, typing past `tw` in insert mode would not auto-break lines — standard vim `tw` behavior would be lost.
+
+**Proposed next step:** Keep as-is. Optional micro-refactor: replace `state.textwidth` reads with `Vim.getOption('textwidth', cm)` so options.js can drop its local `textwidth` registration entirely (tightens the interface).
+
+**Evidence (shared):**
+- `bundle.js:448–466` — `defineOption` implementation
+- `bundle.js:545–560` — upstream `defineOption('textwidth', 80, 'number', ['tw'], …)` — storage only, no wrap side-effect
+- `bundle.js:7767–7768` — `case "textwidth": this.state.textwidth = val;` in CM6 compat `setOption`
+- `bundle.js:2864, 8096–8098` — `hardWrap` consumes textwidth but is called only from the `gq` operator
+- `main.js:290–335` — `editorAPI` compartment reconfigs required for `number`, `tabstop`, `shiftwidth`, `expandtab`, `wrap`
+
+**Cross-file reconciliation:** Upstream's `textwidth` registration is purely a storage slot — it stores the value but never acts on it during insert. So `textwidth.js` must stay (it's the only code providing vim-style auto-wrap on typing). That finding frees `options.js` to remove its `textwidth` registration (lines 56–60) and instead read the value through `Vim.getOption('textwidth', cm)` from the wrap handler. Conversely, because upstream does NOT define `number`, `relativenumber`, `tabstop`, `shiftwidth`, `expandtab`, `wrap`, `spell`, `spelllang`, or `foldgutter`, those registrations in `options.js` are not duplication and must stay.
+
+**Risks / caveats:**
+- Upstream's textwidth default is 80 (bundle:545); ours is 0. If options.js's `textwidth` registration is deleted, `tw` will initialize to 80 by default rather than 0 (disabled). Any slim PR must either leave a no-op `defineOption('textwidth', 0, ...)` to override, or verify that "auto-wrap off by default" is preserved some other way (e.g., `Vim.setOption('textwidth', 0)` at startup).
+- The `flashFn('textwidth=' + val)` side-effect in our current callback (line 59) is user-visible feedback; if removed, users setting `:set tw=72` lose the confirmation flash. Preserve via a `:set` hook or explicit `Vim.defineEx`.
+
+---
+
+### `src/vim/clipboard.js` (keep)
+
+**LoC (non-test):** 23
+**Hypothesis tested:** `@replit/codemirror-vim` natively aliases `"*` to the OS clipboard (or to `"+`) without our shim.
+
+**Verdict:** keep
+
+**Justification:** Upstream only routes `registerName === '+'` to `navigator.clipboard` — the yank path at `bundle:1519–1521` and the paste path at `bundle:3250–3253` both hardcode `'+'` with no `'*'` branch. `validRegisters` at `bundle:366` explicitly lists `['-', '"', '.', ':', '_', '/', '+']` (no `*`), and `isValidRegister` at `bundle:1543` falls back to `latinCharRegex = /^\w$/` (line 367), which excludes `*`, so absent our `defineRegister('*', ...)` call the `*` register would be treated as invalid and silently redirected to the unnamed register. The shim is load-bearing.
+
+**Evidence:**
+- `bundle.js:366` — `var validRegisters = ['-', '"', '.', ':', '_', '/', '+'];` (no `*`)
+- `bundle.js:367` — `var latinCharRegex = /^\w$/;` (excludes `*`)
+- `bundle.js:1467` — `registers['+'] = new Register();` (only `+` pre-registered)
+- `bundle.js:1519–1521` — `if (registerName === '+') { navigator.clipboard.writeText(text); }` — hardcoded `+` only
+- `bundle.js:3250–3253` — paste: `if (actionArgs.registerName === '+') { navigator.clipboard.readText()... }` — hardcoded `+` only
+- `bundle.js:1439–1449` — `defineRegister` is the supported extension point; our shim uses it correctly
+
+**Proposed next step:** No follow-up. Justification above is the record.
+
+**Risks / caveats:** The current test (`clipboard.test.js`) only asserts `defineRegister('*', ...)` was called — it doesn't verify the handlers actually invoke `navigator.clipboard.writeText`. A one-line strengthening would be cheap insurance but isn't required by this audit's scope.
+
+---
+
+### `src/vim/fold.js` (keep)
+
+**LoC (non-test):** 73 (≈50 substantive; rest is JSDoc/blank)
+**Hypothesis tested:** `@codemirror/lang-markdown` detects heading fold ranges natively via `foldNodeProp`/`foldService`, AND `@replit/codemirror-vim` wires `zo`/`zc`/`za`/`zR`/`zM` to those ranges — so `fold.js` is duplicative.
+
+**Verdict:** keep
+
+**Justification:** Half (a) of the hypothesis is confirmed — `lang-markdown` ships a full `foldService` that implements "heading folds until next heading of same-or-lesser depth" (`findSectionEnd`, `lang-markdown/dist/index.js:33–55`), and our file correctly delegates to it rather than re-implementing. Half (b) is **falsified**: a full bundle grep for `"zo"|"zc"|"za"|"zR"|"zM"|foldOpen|foldClose|foldToggle|toggleFold` in `@replit/codemirror-vim/dist/index.js` returns **no matches** — upstream exposes only a `CodeMirror5#foldCode` shim (line 7242) with no keymap wiring. Our `registerFoldCommands()` is the only thing bridging vim keys to CM6's fold service, so it is load-bearing, not duplicative.
+
+**Evidence:**
+- `lang-markdown/dist/index.js:43` — `const headerIndent = foldService.of((state, start, end) => {` (native heading fold detection)
+- `lang-markdown/dist/index.js:33–42` — `findSectionEnd` implements same-or-lesser-depth semantics
+- `language/dist/index.js:1224, 1231, 1237` — `foldService`, `foldNodeProp`, `foldInside` infrastructure
+- `bundle.js` — grep for `"zo"|"zc"|"za"|"zR"|"zM"|foldOpen|foldClose|foldToggle|toggleFold`: **0 matches**
+- `bundle.js:2` — imports only `foldCode` from `@codemirror/language` (no `unfoldCode`, `toggleFold`, `foldAll`, `unfoldAll`), used solely inside the CM5 shim at line 7249
+
+**Proposed next step:** No action — already slim. Optionally add a one-line comment noting that upstream vim has no fold keymap so this bridge is necessary (prevents a future audit from asking the same question).
+
+**Risks / caveats:** The `cm.cm6` access is an undocumented back-door on the CM5 compat shim; if `@replit/codemirror-vim` ever changes that property name, all five actions break silently. Also: `zR`/`zM` currently act globally — vim's true semantics scope them to the current buffer, which happens to coincide since vi.html has one view.
+
+---
+
+### `src/vim/arrow-clamp.js` (keep)
+
+**LoC (non-test):** 29 (implementation ~16)
+**Hypothesis tested:** A CM6 option/extension or `@replit/codemirror-vim` itself prevents Left/Right arrows from wrapping across lines in insert mode, making this file redundant.
+
+**Verdict:** keep
+
+**Justification:** Upstream vim's default keymap maps `<Left>`/`<Right>` to `h`/`l` (bundle:85–86) but without a `context: 'insert'` qualifier — in insert mode these mappings don't apply, so arrows fall through to CM6's default keymap where `moveByChar` explicitly crosses line boundaries (view:3643–3646). Neither package exposes a `whichwrap` option, a `disable-wrap` extension, or any equivalent configuration. Without this file, insert-mode arrows would wrap, diverging from vim's default.
+
+**Evidence:**
+- `bundle.js:85–86` — `{ keys: '<Left>', type: 'keyToKey', toKeys: 'h' }` with no `context: 'insert'`
+- `bundle.js` — zero matches for `whichwrap` or `wrapKeys`
+- `view/dist/index.js:3637–3660` — `moveByChar` unconditionally moves to prev/next line at boundary
+- `commands/dist/index.js` — no `cursorCharLeft`/`cursorCharRight` clamp mode exposed
+
+**Proposed next step:** No follow-up. Consider adding a brief comment pointing to upstream line 85–86 in arrow-clamp.js explaining why this is needed.
+
+**Risks / caveats:** The current clamp action only handles `<Left>`/`<Right>`. Home/End and Shift-Arrow variants still use CM6 defaults; verify whether those should also clamp per vim's `whichwrap` default (`<`,`>`,`[`,`]` restricted to normal/visual only). Not in scope for this audit.
+
+---
+
+### `src/vim/highlight.js` (keep)
+
+**LoC (non-test):** 57 (≈44 substantive)
+**Hypothesis tested:** Every token styled in highlight.js is already styled by `@codemirror/lang-markdown` + `@codemirror/language` defaults, so the file could be deleted or slimmed.
+
+**Verdict:** keep
+
+**Justification:** `@codemirror/lang-markdown` ships **no** default highlight style (grep finds zero references to `HighlightStyle`/`syntaxHighlighting` in its dist), and `main.js:148` installs **only** our custom `getHighlight()` — it never wires in `defaultHighlightStyle`. Even if we did install the default, it uses a single light-theme palette (blues/reds) that clashes with the Paper & Clay / Espresso Mirror warm-cream aesthetic, and it omits `monospace`, `quote`, and `processingInstruction` entirely. The file is load-bearing for both dark-mode support (compartment-swapped at `main.js:524`) and the North Star aesthetic; deletion would leave the editor visually unstyled in dark mode and discordant in light mode.
+
+**Evidence:**
+
+| Token in highlight.js | Upstream default? | Path/line |
+|---|---|---|
+| `heading1`–`heading6` | Partial — only generic `tags.heading` (bold + underline, no color) via tag inheritance | `language/dist/index.js:1802` |
+| `emphasis` | Yes — italic only (no color) | `language/dist/index.js:1805` |
+| `strong` | Yes — bold only (no color) | `language/dist/index.js:1807` |
+| `link` | Yes — underline only (no color) | `language/dist/index.js:1800` |
+| `url` | Yes — color `#219` (clashes with warm palette) | `language/dist/index.js:1813` |
+| `monospace` | **No** | — |
+| `quote` | **No** | — |
+| `processingInstruction` | **No** | — |
+| `contentSeparator` | Yes — color `#219` (clashes) | `language/dist/index.js:1813` |
+
+- `lang-markdown/dist/index.js` — grep for `HighlightStyle|syntaxHighlighting` → 0 matches
+- `main.js:53, 148, 524` — only `getHighlight()` is wired; `defaultHighlightStyle` is never imported
+- `@lezer/markdown/dist/index.js:1955–1969` — confirms our tags are the correct lezer mappings
+- `style.css:181–183` — explicitly defers markdown token colors to `EditorView.theme()` / HighlightStyle in JS
+
+**Proposed next step:** No follow-up. Consider a brief note in the file header stating "lang-markdown ships no default HighlightStyle; this file is the only syntax styling" to inoculate against a future re-audit.
+
+**Risks / caveats:** A deletion would silently break dark-mode token colors and the theme-design palette contract that `highlight.test.js` guards.
+
+---
+
+### Quick-skim batch (all keep)
+
+#### `src/vim/abbreviations.js`
+
+**LoC (non-test):** 132
+**Verdict:** keep
+**Justification:** Upstream has zero abbreviation support — grep for `abbreviat|iabbr|\bab\b` in the bundle returns no matches, and the `exCommands` table (bundle:5868–6389) never registers `ab`/`una`/`abc`. The full implementation (keyword boundary detection, insert-mode `inputHandler`, list/define/delete semantics) is ours to own.
+**Proposed next step:** Keep as-is.
+
+#### `src/vim/buffers.js`
+
+**LoC (non-test):** 235
+**Verdict:** keep
+**Justification:** Browser/app concern with no upstream analogue — CM6 is a single view with no file/buffer concept. All persistence, cursor snapshotting, `#` alternate tracking, and `:ls` rendering is app-specific. Upstream's `write` stub (bundle:6352) just calls `CM.commands.save`, which is unrelated.
+**Proposed next step:** Keep as-is.
+
+#### `src/vim/commands.js`
+
+**LoC (non-test):** 140
+**Verdict:** keep
+**Justification:** Every command registered here routes into app state (buffer manager, tabs, exrc, persistence). Upstream's overlap is limited to a trivial `write` stub (bundle:6352) that our buffer-aware override correctly supersedes. `:registers`, `:sort`, `:marks`, `:global`, etc. from upstream are untouched here (no conflicts). None of the commands we register (`preview`, `edit`, `help`, `write`, `wq`, `quit`, `clear`, `buffer`, `ls`, `buffers`, `bdelete`, `saveas`, `file`, `persist`, `nopersist`, `settings`, `toggle`, `editor`) exist upstream with compatible semantics.
+**Proposed next step:** Keep as-is.
+
+#### `src/vim/exrc.js`
+
+**LoC (non-test):** 106
+**Verdict:** keep
+**Justification:** Persistent startup-config mechanism backed by localStorage — no upstream equivalent (upstream has no storage layer). The `:exrc` in-place editing flow (stash doc / swap to exrc text / restore on `:wq`) is pure app orchestration.
+**Proposed next step:** Keep as-is.
+
+#### `src/vim/mappings.js`
+
+**LoC (non-test):** 14
+**Verdict:** keep
+**Justification:** Two project-specific mappings (`\p` → `:toggle<CR>`, `<C-6>` → `:b#<CR>`). Both depend on Ex commands we defined (`:toggle`, `:b`) and neither exists in upstream `defaultKeymap`. Nothing to slim — file is already at floor.
+**Proposed next step:** Keep as-is.
+
+#### `src/vim/tilde.js`
+
+**LoC (non-test):** 104
+**Verdict:** keep
+**Justification:** Pure CM6 `ViewPlugin` that renders end-of-buffer `~` lines in the scroll DOM — upstream `@replit/codemirror-vim` does no rendering at all (it's an input/state layer). The non-obvious contentDOM height workaround documented inline (lines 73–75) is real.
+**Proposed next step:** Keep as-is.
+
+**Batch summary:** All six files are **keep**. The hypothesis held: upstream has zero abbreviation support, and its `exCommands` table only overlaps with ours on `write`, where upstream's stub just delegates to `CM.commands.save` and is unusable for our buffer model. The four browser/app files (`buffers`, `exrc`, `mappings`, `tilde`) confirm as expected — no upstream equivalent possible.
+
+## Follow-ups filed
+
+| Issue | Title | Affected file(s) | Verdict type |
+|---|---|---|---|
+| [#27](https://github.com/chris-biagini/vi.html/issues/27) | Evaluate replacing gq.js with upstream hardWrap operator | `src/vim/gq.js` | slim (→ possibly delete) |
+| [#28](https://github.com/chris-biagini/vi.html/issues/28) | Remove redundant textwidth defineOption from options.js | `src/vim/options.js` (lines 56–60) | slim (~5 LoC) |
+
+## Memory updates
+
+Applied to `~/.claude/projects/-home-claude-vi-html/memory/cm6_native_coverage.md` (memory lives outside the repo; this list is the committed trace of what changed and why).
+
+A new section titled "Additional native coverage — 2026-04-19 audit (#26)" was appended, recording:
+
+**`@replit/codemirror-vim` provides** (newly documented):
+- `gq`/`gw` operators wired to a real `hardWrap` implementation — bundle:189–190, 2859–2867, 8096–8131. Line-oriented, markdown-unaware. See #27.
+- `"+` register routed to `navigator.clipboard` natively — bundle:1519–1521 yank, 3250–3253 paste. `"*` is NOT — our `clipboard.js` bridges it via `defineRegister`.
+- `textwidth` option as a storage slot only — bundle:545, 7767–7768. Upstream does not auto-wrap on insert.
+- Options defined upstream: only `filetype`, `textwidth`, `langmap`, `pcre`, `insertModeEscKeysTimeout`.
+
+**CM6 packages provide** (newly documented):
+- `@codemirror/lang-markdown` heading `foldService` — `lang-markdown/dist/index.js:33–55`. Same-or-lesser-depth semantics native.
+
+**Confirmed NOT provided** (newly documented as load-bearing negatives):
+- No vim fold keymap wiring in `@replit/codemirror-vim` (`zo`/`zc`/`za`/`zR`/`zM` are our `fold.js` bridge).
+- No `whichwrap` option in either package (our `arrow-clamp.js` is load-bearing).
+- No abbreviations support in the bundle (our `abbreviations.js` is load-bearing).
+- No default `HighlightStyle` in `@codemirror/lang-markdown` (our `highlight.js` is load-bearing).
+- No DOM rendering in `@replit/codemirror-vim` — input/state layer only (our `tilde.js` is load-bearing).
+
+**Rationale:** Future audits of these subsystems can now cite the memory rather than re-grep the bundle. Particularly valuable is the set of confirmed negatives — three files (`arrow-clamp.js`, `abbreviations.js`, `highlight.js`) that looked "suspicious but probably ours" are now documented as verified-ours with line references.
+
+## Closeout
+
+Every file in `src/vim/` has a verdict. Every delete/slim verdict has a follow-up issue. This report ships as a PR that `Resolves #26`. Actual slimming of `gq.js` and `options.js` happens in subsequent branches.


### PR DESCRIPTION
## Summary
- Seven parallel subagents audited all 13 files in `src/vim/` against `@replit/codemirror-vim` (8,774-line bundle) and CodeMirror 6 packages.
- Verdicts: **0 delete, 2 slim, 11 keep** — full table and per-file findings in `docs/plans/2026-04-19-vim-audit.md`.
- **2 follow-up issues filed** — #27 (gq.js → evaluate upstream hardWrap) and #28 (options.js → remove redundant textwidth registration).
- **No source code changed.** This PR is pure documentation; actual slims happen in follow-up branches.
- Memory `cm6_native_coverage` updated with newly-confirmed upstream capabilities and load-bearing negatives.

## Test plan
- [ ] Every file in `src/vim/` has a row in the verdict table (13 rows: gq, options, textwidth, clipboard, fold, arrow-clamp, highlight, abbreviations, buffers, commands, exrc, mappings, tilde).
- [ ] Each slim verdict cites a specific bundle line number (not just a symbol match) — check #27 scope evidence and #28 scope evidence.
- [ ] `npm run check` passes on this branch (no source touched — should be trivially green; 164 tests passed locally).
- [ ] Spot-check one of the "keep" justifications for credibility — e.g., the `clipboard.js` audit's claim that bundle:366's `validRegisters` excludes `*`.

## Key findings

- **`gq.js` — slim (#27):** upstream ships a real `hardWrap` operator keymapped to `gq`/`gw` (bundle:189–190, 2859–2867, 8096–8131). Our override remains load-bearing because upstream's line-by-line merge differs from paragraph-join-then-rewrap and is markdown-unaware. Follow-up does a harness parity test before deciding slim vs. delete.
- **`options.js` — slim (#28):** our `textwidth` `defineOption` duplicates upstream's; 8 of 9 remaining registrations are load-bearing CM6 compartment work. ~5-line slim possible.
- **`clipboard.js` — keep:** upstream routes `\"+` to `navigator.clipboard` but NOT `\"*` — our shim is load-bearing.
- **`fold.js` — keep:** `lang-markdown` provides heading fold ranges, but upstream vim has zero fold keymap (`zo`/`zc`/`za`/`zR`/`zM`). Our bridge is load-bearing.
- **`highlight.js` — keep:** `lang-markdown` ships no default `HighlightStyle`. Our file is the only styling source; deletion would leave the editor visually unstyled.

Resolves #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)